### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ registration.agree_terms
 
 # Let's try to optain a certificate for yourdomain.com
 
-# We need to prove that we control the domain using one of the challanges method.
+# We need to prove that we control the domain using one of the challenges method.
 authorization = client.authorize(domain: 'yourdomain.com')
 
 # For now the only challenge method supprted by the client is simple_http.


### PR DESCRIPTION
@unixcharles, I've corrected a typographical error in the documentation of the [acme-client](https://github.com/unixcharles/acme-client) project. Specifically, I've changed challange to challenge. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.