### PR TITLE
Array.wrap is rails specific.

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -17,7 +17,7 @@ class Acme::Client
 
   def register(contact:)
     payload = {
-      resource: 'new-reg', contact: Array.wrap(contact)
+      resource: 'new-reg', contact: [contact]
     }
 
     response = connection.post(@operation_endpoints.fetch('new-reg'), payload)


### PR DESCRIPTION
Outside of Rails, I'm seeing failures like this:

    > registration = client.register(contact: 'mailto:xxxx@lolware.net')
    NoMethodError: undefined method `wrap' for Array:Class
    from acme-client/lib/acme/client.rb:20:in `register'

As far I understand, a single contact address should be supplied, so this should be accurate.
