### PR TITLE
Replace domains with RF6761 6.5 domains

### DIFF
--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe Acme::Resources::Authorization do
   let(:client) do
     client = Acme::Client.new(private_key: generate_private_key)
-    registration = client.register(contact: 'mailto:info@test.com')
+    registration = client.register(contact: 'mailto:info@example.com')
     registration.agree_terms
     client
   end
 
-  let(:authorization) { client.authorize(domain: 'domain.com')}
+  let(:authorization) { client.authorize(domain: 'example.org')}
 
   context '#http01' do
     it 'returns a HTTP01 object', vcr: { cassette_name: 'authorization_http_01' }  do

--- a/spec/cassettes/authorization_http_01.yml
+++ b/spec/cassettes/authorization_http_01.yml
@@ -62,7 +62,7 @@ http_interactions:
       - '497'
     body:
       encoding: UTF-8
-      string: '{"id":1,"key":{"kty":"RSA","n":"x9Y7M8N19bWHOnYcaGwnBvMuWkY5e2YKLda2GfbU3eG5UKwk5-lZqHA3q78LWEwvHMqBVEmyI937kfSALxWkGrk67prs5kzenmvOk5-phNKDawi5keao7ZU0fROTKYnl3gNHgrSHek4pcklK9FeRw7LwFJ6nKPe3D3WO5r_oZnekOdwVz8I-hSl1lKk4z4ZkqgjEJ1FC8AYPpT1-2iIv3a316YF7wYOeDPhd_qfWI0rju_GToPYlNmKTZ8MpcQtoO8Wr8jD-DjMJz5w3PVFc4XGSGmmdR_TRRyo2kQ0c3bk7g6ofzJZleT1ty9YOC8Q6MwcjpDg1ufQrwHh3tHV7Bw","e":"AQAB"},"contact":["mailto:info@test.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:15.494517333-05:00"}'
+      string: '{"id":1,"key":{"kty":"RSA","n":"x9Y7M8N19bWHOnYcaGwnBvMuWkY5e2YKLda2GfbU3eG5UKwk5-lZqHA3q78LWEwvHMqBVEmyI937kfSALxWkGrk67prs5kzenmvOk5-phNKDawi5keao7ZU0fROTKYnl3gNHgrSHek4pcklK9FeRw7LwFJ6nKPe3D3WO5r_oZnekOdwVz8I-hSl1lKk4z4ZkqgjEJ1FC8AYPpT1-2iIv3a316YF7wYOeDPhd_qfWI0rju_GToPYlNmKTZ8MpcQtoO8Wr8jD-DjMJz5w3PVFc4XGSGmmdR_TRRyo2kQ0c3bk7g6ofzJZleT1ty9YOC8Q6MwcjpDg1ufQrwHh3tHV7Bw","e":"AQAB"},"contact":["mailto:info@example.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:15.494517333-05:00"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:15 GMT
 - request:
@@ -96,7 +96,7 @@ http_interactions:
       - '527'
     body:
       encoding: UTF-8
-      string: '{"id":1,"key":{"kty":"RSA","n":"x9Y7M8N19bWHOnYcaGwnBvMuWkY5e2YKLda2GfbU3eG5UKwk5-lZqHA3q78LWEwvHMqBVEmyI937kfSALxWkGrk67prs5kzenmvOk5-phNKDawi5keao7ZU0fROTKYnl3gNHgrSHek4pcklK9FeRw7LwFJ6nKPe3D3WO5r_oZnekOdwVz8I-hSl1lKk4z4ZkqgjEJ1FC8AYPpT1-2iIv3a316YF7wYOeDPhd_qfWI0rju_GToPYlNmKTZ8MpcQtoO8Wr8jD-DjMJz5w3PVFc4XGSGmmdR_TRRyo2kQ0c3bk7g6ofzJZleT1ty9YOC8Q6MwcjpDg1ufQrwHh3tHV7Bw","e":"AQAB"},"contact":["mailto:info@test.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:15Z"}'
+      string: '{"id":1,"key":{"kty":"RSA","n":"x9Y7M8N19bWHOnYcaGwnBvMuWkY5e2YKLda2GfbU3eG5UKwk5-lZqHA3q78LWEwvHMqBVEmyI937kfSALxWkGrk67prs5kzenmvOk5-phNKDawi5keao7ZU0fROTKYnl3gNHgrSHek4pcklK9FeRw7LwFJ6nKPe3D3WO5r_oZnekOdwVz8I-hSl1lKk4z4ZkqgjEJ1FC8AYPpT1-2iIv3a316YF7wYOeDPhd_qfWI0rju_GToPYlNmKTZ8MpcQtoO8Wr8jD-DjMJz5w3PVFc4XGSGmmdR_TRRyo2kQ0c3bk7g6ofzJZleT1ty9YOC8Q6MwcjpDg1ufQrwHh3tHV7Bw","e":"AQAB"},"contact":["mailto:info@example.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:15Z"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:15 GMT
 - request:
@@ -131,7 +131,7 @@ http_interactions:
       - '1098'
     body:
       encoding: UTF-8
-      string: '{"identifier":{"type":"dns","value":"domain.com"},"status":"pending","expires":"2015-12-04T16:16:15.525639498-05:00","challenges":[{"type":"tls-sni-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/6Wl445YhIsaHjnEvI2Zmdezs6pX80rFaKESHanbEO_I/1","token":"0YTI4sO18BWfn9wrMlnBp9_i5mhrXO3u4SVJp9NoI8c"},{"type":"simpleHttp","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/6Wl445YhIsaHjnEvI2Zmdezs6pX80rFaKESHanbEO_I/2","token":"4z0bIiC4L9EGL4H9hJ3Bs2TfK6JQywDgOc7rIBVGMpw","tls":true},{"type":"dvsni","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/6Wl445YhIsaHjnEvI2Zmdezs6pX80rFaKESHanbEO_I/3","token":"jfc6dubsH1tojeKQmzvyfzOASUrr00R50gdRYrkpu64"},{"type":"dns-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/6Wl445YhIsaHjnEvI2Zmdezs6pX80rFaKESHanbEO_I/4","token":"bqZDMt_HcbKzxJxsGShheDZaZw19yTz6tr_PdHfCOuM"},{"type":"http-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/6Wl445YhIsaHjnEvI2Zmdezs6pX80rFaKESHanbEO_I/5","token":"jSApNp2YYfdMPgQMMebjVQozseH3fpYTv6A-_D-W7tk"}],"combinations":[[3],[4],[0],[1],[2]]}'
+      string: '{"identifier":{"type":"dns","value":"example.org"},"status":"pending","expires":"2015-12-04T16:16:15.525639498-05:00","challenges":[{"type":"tls-sni-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/6Wl445YhIsaHjnEvI2Zmdezs6pX80rFaKESHanbEO_I/1","token":"0YTI4sO18BWfn9wrMlnBp9_i5mhrXO3u4SVJp9NoI8c"},{"type":"simpleHttp","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/6Wl445YhIsaHjnEvI2Zmdezs6pX80rFaKESHanbEO_I/2","token":"4z0bIiC4L9EGL4H9hJ3Bs2TfK6JQywDgOc7rIBVGMpw","tls":true},{"type":"dvsni","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/6Wl445YhIsaHjnEvI2Zmdezs6pX80rFaKESHanbEO_I/3","token":"jfc6dubsH1tojeKQmzvyfzOASUrr00R50gdRYrkpu64"},{"type":"dns-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/6Wl445YhIsaHjnEvI2Zmdezs6pX80rFaKESHanbEO_I/4","token":"bqZDMt_HcbKzxJxsGShheDZaZw19yTz6tr_PdHfCOuM"},{"type":"http-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/6Wl445YhIsaHjnEvI2Zmdezs6pX80rFaKESHanbEO_I/5","token":"jSApNp2YYfdMPgQMMebjVQozseH3fpYTv6A-_D-W7tk"}],"combinations":[[3],[4],[0],[1],[2]]}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/authorize_fail_tos.yml
+++ b/spec/cassettes/authorize_fail_tos.yml
@@ -62,7 +62,7 @@ http_interactions:
       - '497'
     body:
       encoding: UTF-8
-      string: '{"id":5,"key":{"kty":"RSA","n":"qJrlqBvoKrENk2jNZBJPlrcH1lC_1MM8lz_y_dpTASYdysGnnyeWX8bG3xtcbpXdJLdwOaHRM2HwQLVV5NjsM1Yz56obo5AJN0NS1s0Y0iyTrqxxcn2hRaTExtZfibp4Yy1EGYI4psjrveyIyavU5IbVtnVCSnqfzaanNtOkkQdJR4nkkqp4qb8MLRkZ4A9vKWz-X1ziRpfihRr3DlfQRYcYe_wj-V1pfQxCyWP1x8MyscNCITyI3I7VX0ZGU_ETE9NP29Olch3j8xNaVujwDXzw80S4l__OGmx31GawsBLpQwAitn7wWMJ5zxbFArkmeNpmr5pNkjO1HHMyyiXrvQ","e":"AQAB"},"contact":["mailto:mail@test.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:16.398262936-05:00"}'
+      string: '{"id":5,"key":{"kty":"RSA","n":"qJrlqBvoKrENk2jNZBJPlrcH1lC_1MM8lz_y_dpTASYdysGnnyeWX8bG3xtcbpXdJLdwOaHRM2HwQLVV5NjsM1Yz56obo5AJN0NS1s0Y0iyTrqxxcn2hRaTExtZfibp4Yy1EGYI4psjrveyIyavU5IbVtnVCSnqfzaanNtOkkQdJR4nkkqp4qb8MLRkZ4A9vKWz-X1ziRpfihRr3DlfQRYcYe_wj-V1pfQxCyWP1x8MyscNCITyI3I7VX0ZGU_ETE9NP29Olch3j8xNaVujwDXzw80S4l__OGmx31GawsBLpQwAitn7wWMJ5zxbFArkmeNpmr5pNkjO1HHMyyiXrvQ","e":"AQAB"},"contact":["mailto:mail@example.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:16.398262936-05:00"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:

--- a/spec/cassettes/authorize_invalid_domain.yml
+++ b/spec/cassettes/authorize_invalid_domain.yml
@@ -62,7 +62,7 @@ http_interactions:
       - '497'
     body:
       encoding: UTF-8
-      string: '{"id":6,"key":{"kty":"RSA","n":"o5XoaQ0gpcItjov0ZLwAiLyFaNy94g1Tru-MOg3n3P5XmTigVtNSDq6n3CHPp5G-4EtifS2b1gdL9-lXF7nt9dWqujsNeJnXNm9acK5fzNu7c4tTtv-z4CNhZQtXduY5scLjVaAcP8bltT3t9hLg_hUnFw0uEPGaGNKRbKGdgue5txwyWl3GCTJw07OodzcRG0TMxAe1EHiG_c8O2bBP4wJjcHJv6hz0QfNBIhxpUcxnzEVXu-KlXWDMzbzOaCcXRfZHh6nKpgsjBP2f2S80vSm99aySHqafuPaHjb83fm--GgBYabDPmwSWHgJodqn9s7fNVlCzFF9rT06emtVJxw","e":"AQAB"},"contact":["mailto:mail@test.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:16.447257867-05:00"}'
+      string: '{"id":6,"key":{"kty":"RSA","n":"o5XoaQ0gpcItjov0ZLwAiLyFaNy94g1Tru-MOg3n3P5XmTigVtNSDq6n3CHPp5G-4EtifS2b1gdL9-lXF7nt9dWqujsNeJnXNm9acK5fzNu7c4tTtv-z4CNhZQtXduY5scLjVaAcP8bltT3t9hLg_hUnFw0uEPGaGNKRbKGdgue5txwyWl3GCTJw07OodzcRG0TMxAe1EHiG_c8O2bBP4wJjcHJv6hz0QfNBIhxpUcxnzEVXu-KlXWDMzbzOaCcXRfZHh6nKpgsjBP2f2S80vSm99aySHqafuPaHjb83fm--GgBYabDPmwSWHgJodqn9s7fNVlCzFF9rT06emtVJxw","e":"AQAB"},"contact":["mailto:mail@example.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:16.447257867-05:00"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:
@@ -96,7 +96,7 @@ http_interactions:
       - '527'
     body:
       encoding: UTF-8
-      string: '{"id":6,"key":{"kty":"RSA","n":"o5XoaQ0gpcItjov0ZLwAiLyFaNy94g1Tru-MOg3n3P5XmTigVtNSDq6n3CHPp5G-4EtifS2b1gdL9-lXF7nt9dWqujsNeJnXNm9acK5fzNu7c4tTtv-z4CNhZQtXduY5scLjVaAcP8bltT3t9hLg_hUnFw0uEPGaGNKRbKGdgue5txwyWl3GCTJw07OodzcRG0TMxAe1EHiG_c8O2bBP4wJjcHJv6hz0QfNBIhxpUcxnzEVXu-KlXWDMzbzOaCcXRfZHh6nKpgsjBP2f2S80vSm99aySHqafuPaHjb83fm--GgBYabDPmwSWHgJodqn9s7fNVlCzFF9rT06emtVJxw","e":"AQAB"},"contact":["mailto:mail@test.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:16Z"}'
+      string: '{"id":6,"key":{"kty":"RSA","n":"o5XoaQ0gpcItjov0ZLwAiLyFaNy94g1Tru-MOg3n3P5XmTigVtNSDq6n3CHPp5G-4EtifS2b1gdL9-lXF7nt9dWqujsNeJnXNm9acK5fzNu7c4tTtv-z4CNhZQtXduY5scLjVaAcP8bltT3t9hLg_hUnFw0uEPGaGNKRbKGdgue5txwyWl3GCTJw07OodzcRG0TMxAe1EHiG_c8O2bBP4wJjcHJv6hz0QfNBIhxpUcxnzEVXu-KlXWDMzbzOaCcXRfZHh6nKpgsjBP2f2S80vSm99aySHqafuPaHjb83fm--GgBYabDPmwSWHgJodqn9s7fNVlCzFF9rT06emtVJxw","e":"AQAB"},"contact":["mailto:mail@example.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:16Z"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:

--- a/spec/cassettes/authorize_success.yml
+++ b/spec/cassettes/authorize_success.yml
@@ -62,7 +62,7 @@ http_interactions:
       - '497'
     body:
       encoding: UTF-8
-      string: '{"id":4,"key":{"kty":"RSA","n":"tUezqaS8Id2q-oQQBoC70ZPc42Y_0k-4Q8T2d83XkwWM4XMDsRqoTQQ_xB9NinQy0OqzbRn53SSwWD27tWMHVniQW0gbF30C1m9MT6Eu-xzFHC_7gVnJrAQ7NPnei1CJ6shnPGLULjIQ58ktCGUBQGgClOI-ISL8WpCiGQRdCEqtpHNJqTC-eATyRN9S7Xak6odDhNUKuyjyVD7a75BMc6ox1rNfe2wk1ZSluOOKxl7oK-DIIIvcGQ-JiaLXPie5DdMfa_lPbS-JSRdHw3tPQTiq0qmxWUhJLRGzxD06H8HwGyFn-kicwB1IgR2agRPayy-WIih1HqQ3_J9j1XJVIQ","e":"AQAB"},"contact":["mailto:mail@test.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:16.289440976-05:00"}'
+      string: '{"id":4,"key":{"kty":"RSA","n":"tUezqaS8Id2q-oQQBoC70ZPc42Y_0k-4Q8T2d83XkwWM4XMDsRqoTQQ_xB9NinQy0OqzbRn53SSwWD27tWMHVniQW0gbF30C1m9MT6Eu-xzFHC_7gVnJrAQ7NPnei1CJ6shnPGLULjIQ58ktCGUBQGgClOI-ISL8WpCiGQRdCEqtpHNJqTC-eATyRN9S7Xak6odDhNUKuyjyVD7a75BMc6ox1rNfe2wk1ZSluOOKxl7oK-DIIIvcGQ-JiaLXPie5DdMfa_lPbS-JSRdHw3tPQTiq0qmxWUhJLRGzxD06H8HwGyFn-kicwB1IgR2agRPayy-WIih1HqQ3_J9j1XJVIQ","e":"AQAB"},"contact":["mailto:mail@example.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:16.289440976-05:00"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:
@@ -96,7 +96,7 @@ http_interactions:
       - '527'
     body:
       encoding: UTF-8
-      string: '{"id":4,"key":{"kty":"RSA","n":"tUezqaS8Id2q-oQQBoC70ZPc42Y_0k-4Q8T2d83XkwWM4XMDsRqoTQQ_xB9NinQy0OqzbRn53SSwWD27tWMHVniQW0gbF30C1m9MT6Eu-xzFHC_7gVnJrAQ7NPnei1CJ6shnPGLULjIQ58ktCGUBQGgClOI-ISL8WpCiGQRdCEqtpHNJqTC-eATyRN9S7Xak6odDhNUKuyjyVD7a75BMc6ox1rNfe2wk1ZSluOOKxl7oK-DIIIvcGQ-JiaLXPie5DdMfa_lPbS-JSRdHw3tPQTiq0qmxWUhJLRGzxD06H8HwGyFn-kicwB1IgR2agRPayy-WIih1HqQ3_J9j1XJVIQ","e":"AQAB"},"contact":["mailto:mail@test.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:16Z"}'
+      string: '{"id":4,"key":{"kty":"RSA","n":"tUezqaS8Id2q-oQQBoC70ZPc42Y_0k-4Q8T2d83XkwWM4XMDsRqoTQQ_xB9NinQy0OqzbRn53SSwWD27tWMHVniQW0gbF30C1m9MT6Eu-xzFHC_7gVnJrAQ7NPnei1CJ6shnPGLULjIQ58ktCGUBQGgClOI-ISL8WpCiGQRdCEqtpHNJqTC-eATyRN9S7Xak6odDhNUKuyjyVD7a75BMc6ox1rNfe2wk1ZSluOOKxl7oK-DIIIvcGQ-JiaLXPie5DdMfa_lPbS-JSRdHw3tPQTiq0qmxWUhJLRGzxD06H8HwGyFn-kicwB1IgR2agRPayy-WIih1HqQ3_J9j1XJVIQ","e":"AQAB"},"contact":["mailto:mail@example.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:16Z"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:
@@ -131,7 +131,7 @@ http_interactions:
       - '1099'
     body:
       encoding: UTF-8
-      string: '{"identifier":{"type":"dns","value":"domain.com"},"status":"pending","expires":"2015-12-04T16:16:16.312630273-05:00","challenges":[{"type":"http-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/pasZua5nX6jgI6jF_sl2tHRnTDRO8lsFnI1kLdyWSdA/6","token":"wJ2OPM2QixIx_U37NKC57uAHhTa97y8yEsoCui4r0-U"},{"type":"dvsni","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/pasZua5nX6jgI6jF_sl2tHRnTDRO8lsFnI1kLdyWSdA/7","token":"IfoZBt7yx6lIbH8crKVnnQ7LO2TjmYgUPXkMEVbsHiY"},{"type":"tls-sni-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/pasZua5nX6jgI6jF_sl2tHRnTDRO8lsFnI1kLdyWSdA/8","token":"Ty4QS3KC6IAPLCwoilaxpWUQNfEiq6h6kPCvTxS31no"},{"type":"simpleHttp","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/pasZua5nX6jgI6jF_sl2tHRnTDRO8lsFnI1kLdyWSdA/9","token":"81CS2X4IKoD8aDqdCfMDbq9iLfT_s1phykgPuc_nB_k","tls":true},{"type":"dns-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/pasZua5nX6jgI6jF_sl2tHRnTDRO8lsFnI1kLdyWSdA/10","token":"Lx6ZqnswawundrKnASEDkXXB8_2v0JTx1-IZiScBkNI"}],"combinations":[[0],[3],[2],[1],[4]]}'
+      string: '{"identifier":{"type":"dns","value":"example.org"},"status":"pending","expires":"2015-12-04T16:16:16.312630273-05:00","challenges":[{"type":"http-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/pasZua5nX6jgI6jF_sl2tHRnTDRO8lsFnI1kLdyWSdA/6","token":"wJ2OPM2QixIx_U37NKC57uAHhTa97y8yEsoCui4r0-U"},{"type":"dvsni","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/pasZua5nX6jgI6jF_sl2tHRnTDRO8lsFnI1kLdyWSdA/7","token":"IfoZBt7yx6lIbH8crKVnnQ7LO2TjmYgUPXkMEVbsHiY"},{"type":"tls-sni-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/pasZua5nX6jgI6jF_sl2tHRnTDRO8lsFnI1kLdyWSdA/8","token":"Ty4QS3KC6IAPLCwoilaxpWUQNfEiq6h6kPCvTxS31no"},{"type":"simpleHttp","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/pasZua5nX6jgI6jF_sl2tHRnTDRO8lsFnI1kLdyWSdA/9","token":"81CS2X4IKoD8aDqdCfMDbq9iLfT_s1phykgPuc_nB_k","tls":true},{"type":"dns-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/pasZua5nX6jgI6jF_sl2tHRnTDRO8lsFnI1kLdyWSdA/10","token":"Lx6ZqnswawundrKnASEDkXXB8_2v0JTx1-IZiScBkNI"}],"combinations":[[0],[3],[2],[1],[4]]}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/http01_verify_failure.yml
+++ b/spec/cassettes/http01_verify_failure.yml
@@ -62,7 +62,7 @@ http_interactions:
       - '497'
     body:
       encoding: UTF-8
-      string: '{"id":9,"key":{"kty":"RSA","n":"121qBENAyK3w8Or33QsXKIrb0th0uZViaemLYYNt3-pAsILsUPPmgDTW9FHyugnnMk7f5PwzNsTmx322SFYqjyzYgWfDG6kEeJFcY4Yzg7as-Wipda1P3xHy020EQ-6QhU8UO0OO21aBalEoapYPBKQmQCnKcHFsyRHrTjQ0yWzVP2Ime_NZej1jzg8kK0HuRcPs4c1K56LPLVUtXCJ4IR1r_WkWPzue1XjD6aC9MWY5_doYJ3zcdzkFrRzxrK0y6f78P0PdmCY2jdFwNUkw0468WIGq1kdTFS-dX4oGvnILYV2UlMCvVA8WjRqUYNNTkLB3Et0J0ayH5E0zDxGz1Q","e":"AQAB"},"contact":["mailto:info@test.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:17.016243364-05:00"}'
+      string: '{"id":9,"key":{"kty":"RSA","n":"121qBENAyK3w8Or33QsXKIrb0th0uZViaemLYYNt3-pAsILsUPPmgDTW9FHyugnnMk7f5PwzNsTmx322SFYqjyzYgWfDG6kEeJFcY4Yzg7as-Wipda1P3xHy020EQ-6QhU8UO0OO21aBalEoapYPBKQmQCnKcHFsyRHrTjQ0yWzVP2Ime_NZej1jzg8kK0HuRcPs4c1K56LPLVUtXCJ4IR1r_WkWPzue1XjD6aC9MWY5_doYJ3zcdzkFrRzxrK0y6f78P0PdmCY2jdFwNUkw0468WIGq1kdTFS-dX4oGvnILYV2UlMCvVA8WjRqUYNNTkLB3Et0J0ayH5E0zDxGz1Q","e":"AQAB"},"contact":["mailto:info@example.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:17.016243364-05:00"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:17 GMT
 - request:
@@ -96,7 +96,7 @@ http_interactions:
       - '527'
     body:
       encoding: UTF-8
-      string: '{"id":9,"key":{"kty":"RSA","n":"121qBENAyK3w8Or33QsXKIrb0th0uZViaemLYYNt3-pAsILsUPPmgDTW9FHyugnnMk7f5PwzNsTmx322SFYqjyzYgWfDG6kEeJFcY4Yzg7as-Wipda1P3xHy020EQ-6QhU8UO0OO21aBalEoapYPBKQmQCnKcHFsyRHrTjQ0yWzVP2Ime_NZej1jzg8kK0HuRcPs4c1K56LPLVUtXCJ4IR1r_WkWPzue1XjD6aC9MWY5_doYJ3zcdzkFrRzxrK0y6f78P0PdmCY2jdFwNUkw0468WIGq1kdTFS-dX4oGvnILYV2UlMCvVA8WjRqUYNNTkLB3Et0J0ayH5E0zDxGz1Q","e":"AQAB"},"contact":["mailto:info@test.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:17Z"}'
+      string: '{"id":9,"key":{"kty":"RSA","n":"121qBENAyK3w8Or33QsXKIrb0th0uZViaemLYYNt3-pAsILsUPPmgDTW9FHyugnnMk7f5PwzNsTmx322SFYqjyzYgWfDG6kEeJFcY4Yzg7as-Wipda1P3xHy020EQ-6QhU8UO0OO21aBalEoapYPBKQmQCnKcHFsyRHrTjQ0yWzVP2Ime_NZej1jzg8kK0HuRcPs4c1K56LPLVUtXCJ4IR1r_WkWPzue1XjD6aC9MWY5_doYJ3zcdzkFrRzxrK0y6f78P0PdmCY2jdFwNUkw0468WIGq1kdTFS-dX4oGvnILYV2UlMCvVA8WjRqUYNNTkLB3Et0J0ayH5E0zDxGz1Q","e":"AQAB"},"contact":["mailto:info@example.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:17Z"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:17 GMT
 - request:
@@ -131,7 +131,7 @@ http_interactions:
       - '1114'
     body:
       encoding: UTF-8
-      string: '{"identifier":{"type":"dns","value":"test97.testdomain.com"},"status":"pending","expires":"2015-12-04T16:16:17.040239285-05:00","challenges":[{"type":"tls-sni-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/21","token":"KQsRsIphuJrwLPJS5daIhg-ZaZoyXn_7cnBizUNu6kM"},{"type":"dvsni","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/22","token":"2Qqd7Z4sKVdDv62QE846gVRJNvMDRcpCEkAe-dOuAFI"},{"type":"dns-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/23","token":"ZrDI6hUGKKch5D8lQVxS_npFgV5RUuwjfz3pYVINFC0"},{"type":"http-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/24","token":"JzO8iiYXAtAGYoCzQg6UujScHrj43CkP5Kms9pB67Fc"},{"type":"simpleHttp","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/25","token":"ZljXMuA9jm9d-eFZ7uGfwD1LAuehQnoGwFtmQ41HAMM","tls":true}],"combinations":[[0],[2],[4],[1],[3]]}'
+      string: '{"identifier":{"type":"dns","value":"test97.testexample.org"},"status":"pending","expires":"2015-12-04T16:16:17.040239285-05:00","challenges":[{"type":"tls-sni-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/21","token":"KQsRsIphuJrwLPJS5daIhg-ZaZoyXn_7cnBizUNu6kM"},{"type":"dvsni","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/22","token":"2Qqd7Z4sKVdDv62QE846gVRJNvMDRcpCEkAe-dOuAFI"},{"type":"dns-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/23","token":"ZrDI6hUGKKch5D8lQVxS_npFgV5RUuwjfz3pYVINFC0"},{"type":"http-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/24","token":"JzO8iiYXAtAGYoCzQg6UujScHrj43CkP5Kms9pB67Fc"},{"type":"simpleHttp","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/25","token":"ZljXMuA9jm9d-eFZ7uGfwD1LAuehQnoGwFtmQ41HAMM","tls":true}],"combinations":[[0],[2],[4],[1],[3]]}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:17 GMT
 - request:
@@ -237,7 +237,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"type":"http-01","status":"invalid","error":{"type":"urn:acme:error:unauthorized","detail":"Error
-        parsing key authorization file: Invalid key authorization: malformed key thumbprint"},"uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/24","token":"JzO8iiYXAtAGYoCzQg6UujScHrj43CkP5Kms9pB67Fc","keyAuthorization":"JzO8iiYXAtAGYoCzQg6UujScHrj43CkP5Kms9pB67Fc.-LRTkkT36kdRvT4ykIkNHFClr7NbETJHbqOyFo02_1o","validationRecord":[{"url":"http://test97.testdomain.com:5002/.well-known/acme-challenge/JzO8iiYXAtAGYoCzQg6UujScHrj43CkP5Kms9pB67Fc","hostname":"test97.testdomain.com","port":"5002","addressesResolved":["127.0.0.1"],"addressUsed":"127.0.0.1"}]}'
+        parsing key authorization file: Invalid key authorization: malformed key thumbprint"},"uri":"http://127.0.0.1:4000/acme/challenge/tMk_DFPF_wzjwkm7FK3fccoiJqWkt686RecKIaTrrt8/24","token":"JzO8iiYXAtAGYoCzQg6UujScHrj43CkP5Kms9pB67Fc","keyAuthorization":"JzO8iiYXAtAGYoCzQg6UujScHrj43CkP5Kms9pB67Fc.-LRTkkT36kdRvT4ykIkNHFClr7NbETJHbqOyFo02_1o","validationRecord":[{"url":"http://test97.testexample.org:5002/.well-known/acme-challenge/JzO8iiYXAtAGYoCzQg6UujScHrj43CkP5Kms9pB67Fc","hostname":"test97.testexample.org","port":"5002","addressesResolved":["127.0.0.1"],"addressUsed":"127.0.0.1"}]}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/http01_verify_success.yml
+++ b/spec/cassettes/http01_verify_success.yml
@@ -62,7 +62,7 @@ http_interactions:
       - '497'
     body:
       encoding: UTF-8
-      string: '{"id":8,"key":{"kty":"RSA","n":"l_eSb_069_gfY3mzfj1pYavs-KwYY_y2MclHA4lazl3SEQeD5HO2sWhmpeQrCbcyYSshNBJLa6Euwyj7fquW2Vy65c3tHf8DyxfcF_ha4JNHObXx0UREZjhBUWO3vUg6PJ9bHjfDB8uoCrFwXU8ksUMwZuF4neVtnZPqBCXEXXhMxZueF7jHXi7M3thUe09kOyKxkUYjeDo2ssXWZcNgn5BmlZP_I9J_NVwdYLmfSlz1StlEEG4iwsqnxQ5wATMdBFCrH8Yme6juYvB7CSEqKg32SpF51tV9_4UG1_W7C3XQfdWgzjbSRud8RiaElQiky7q5YIgJ3ru_T-5kqNpjWQ","e":"AQAB"},"contact":["mailto:info@test.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:16.875256047-05:00"}'
+      string: '{"id":8,"key":{"kty":"RSA","n":"l_eSb_069_gfY3mzfj1pYavs-KwYY_y2MclHA4lazl3SEQeD5HO2sWhmpeQrCbcyYSshNBJLa6Euwyj7fquW2Vy65c3tHf8DyxfcF_ha4JNHObXx0UREZjhBUWO3vUg6PJ9bHjfDB8uoCrFwXU8ksUMwZuF4neVtnZPqBCXEXXhMxZueF7jHXi7M3thUe09kOyKxkUYjeDo2ssXWZcNgn5BmlZP_I9J_NVwdYLmfSlz1StlEEG4iwsqnxQ5wATMdBFCrH8Yme6juYvB7CSEqKg32SpF51tV9_4UG1_W7C3XQfdWgzjbSRud8RiaElQiky7q5YIgJ3ru_T-5kqNpjWQ","e":"AQAB"},"contact":["mailto:info@example.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:16.875256047-05:00"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:
@@ -96,7 +96,7 @@ http_interactions:
       - '527'
     body:
       encoding: UTF-8
-      string: '{"id":8,"key":{"kty":"RSA","n":"l_eSb_069_gfY3mzfj1pYavs-KwYY_y2MclHA4lazl3SEQeD5HO2sWhmpeQrCbcyYSshNBJLa6Euwyj7fquW2Vy65c3tHf8DyxfcF_ha4JNHObXx0UREZjhBUWO3vUg6PJ9bHjfDB8uoCrFwXU8ksUMwZuF4neVtnZPqBCXEXXhMxZueF7jHXi7M3thUe09kOyKxkUYjeDo2ssXWZcNgn5BmlZP_I9J_NVwdYLmfSlz1StlEEG4iwsqnxQ5wATMdBFCrH8Yme6juYvB7CSEqKg32SpF51tV9_4UG1_W7C3XQfdWgzjbSRud8RiaElQiky7q5YIgJ3ru_T-5kqNpjWQ","e":"AQAB"},"contact":["mailto:info@test.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:16Z"}'
+      string: '{"id":8,"key":{"kty":"RSA","n":"l_eSb_069_gfY3mzfj1pYavs-KwYY_y2MclHA4lazl3SEQeD5HO2sWhmpeQrCbcyYSshNBJLa6Euwyj7fquW2Vy65c3tHf8DyxfcF_ha4JNHObXx0UREZjhBUWO3vUg6PJ9bHjfDB8uoCrFwXU8ksUMwZuF4neVtnZPqBCXEXXhMxZueF7jHXi7M3thUe09kOyKxkUYjeDo2ssXWZcNgn5BmlZP_I9J_NVwdYLmfSlz1StlEEG4iwsqnxQ5wATMdBFCrH8Yme6juYvB7CSEqKg32SpF51tV9_4UG1_W7C3XQfdWgzjbSRud8RiaElQiky7q5YIgJ3ru_T-5kqNpjWQ","e":"AQAB"},"contact":["mailto:info@example.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:16Z"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:
@@ -131,7 +131,7 @@ http_interactions:
       - '1113'
     body:
       encoding: UTF-8
-      string: '{"identifier":{"type":"dns","value":"test4.testdomain.com"},"status":"pending","expires":"2015-12-04T16:16:16.898852524-05:00","challenges":[{"type":"http-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/16","token":"DRp3SSd-RG5eVXiCAMgb2s1mPU5pHDiGOTh3ue42KLg"},{"type":"tls-sni-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/17","token":"l4WGDGy7nQ_9SNybllPDQ1hApe0IexTEoGhSZz8Rvb0"},{"type":"dvsni","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/18","token":"dpLEvsR1LqnLJdgsCB0cN5O1Ji8M_P2bPOVa5ghDZZY"},{"type":"simpleHttp","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/19","token":"2YAzVpBflOrK2D0lV5SEH5FC8fhr7PH1IV1ylbpehjE","tls":true},{"type":"dns-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/20","token":"f3YGZ4xxs_WWpUkLK_EUu77p2vDsI_RixHXeIXCXGoI"}],"combinations":[[1],[2],[0],[4],[3]]}'
+      string: '{"identifier":{"type":"dns","value":"test4.testexample.org"},"status":"pending","expires":"2015-12-04T16:16:16.898852524-05:00","challenges":[{"type":"http-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/16","token":"DRp3SSd-RG5eVXiCAMgb2s1mPU5pHDiGOTh3ue42KLg"},{"type":"tls-sni-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/17","token":"l4WGDGy7nQ_9SNybllPDQ1hApe0IexTEoGhSZz8Rvb0"},{"type":"dvsni","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/18","token":"dpLEvsR1LqnLJdgsCB0cN5O1Ji8M_P2bPOVa5ghDZZY"},{"type":"simpleHttp","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/19","token":"2YAzVpBflOrK2D0lV5SEH5FC8fhr7PH1IV1ylbpehjE","tls":true},{"type":"dns-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/20","token":"f3YGZ4xxs_WWpUkLK_EUu77p2vDsI_RixHXeIXCXGoI"}],"combinations":[[1],[2],[0],[4],[3]]}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:
@@ -236,7 +236,7 @@ http_interactions:
       - '533'
     body:
       encoding: UTF-8
-      string: '{"type":"http-01","status":"valid","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/16","token":"DRp3SSd-RG5eVXiCAMgb2s1mPU5pHDiGOTh3ue42KLg","keyAuthorization":"DRp3SSd-RG5eVXiCAMgb2s1mPU5pHDiGOTh3ue42KLg.8NcnpZqegT0CCBAn97dMkciN0gIR4DH2i-F6daqgM_E","validationRecord":[{"url":"http://test4.testdomain.com:5002/.well-known/acme-challenge/DRp3SSd-RG5eVXiCAMgb2s1mPU5pHDiGOTh3ue42KLg","hostname":"test4.testdomain.com","port":"5002","addressesResolved":["127.0.0.1"],"addressUsed":"127.0.0.1"}]}'
+      string: '{"type":"http-01","status":"valid","uri":"http://127.0.0.1:4000/acme/challenge/eCnXJAw2QMmQw60dnsiLhbVNqciAbBq5qDg89l-xhuA/16","token":"DRp3SSd-RG5eVXiCAMgb2s1mPU5pHDiGOTh3ue42KLg","keyAuthorization":"DRp3SSd-RG5eVXiCAMgb2s1mPU5pHDiGOTh3ue42KLg.8NcnpZqegT0CCBAn97dMkciN0gIR4DH2i-F6daqgM_E","validationRecord":[{"url":"http://test4.testexample.org:5002/.well-known/acme-challenge/DRp3SSd-RG5eVXiCAMgb2s1mPU5pHDiGOTh3ue42KLg","hostname":"test4.testexample.org","port":"5002","addressesResolved":["127.0.0.1"],"addressUsed":"127.0.0.1"}]}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/new_certificate_success.yml
+++ b/spec/cassettes/new_certificate_success.yml
@@ -62,7 +62,7 @@ http_interactions:
       - '497'
     body:
       encoding: UTF-8
-      string: '{"id":7,"key":{"kty":"RSA","n":"tRV-Cklf3t1270t-DiOd2C3U0qZdGwWna4guV_3abMHUSS3WPf0_mvvt4lHuUrStPbip_uwetL_YMEXNGEFWRseKLRy17usaUwBN1c4R2uw50qb5coEeSoNQTS_v_qcHBD8ko8t63TTaVNjytLk3ql-xIgFuJCdedGWDtLEAdr73tWbp9n5Akm7LhsrzlWjFu5NsbnJzYtkL2ZY3ETc5gSdRLdA7oRcqpwcTXajy5GTsmwQO2U8bQIjzdzGLRGrC2_XxY_Co8r2CBnZopfFlUG3hC4rtubxM4tQvp5topb1swrSCGT7vYZ_vWUBgi0Td7X6xcw4mjSDLmH23yyXYgQ","e":"AQAB"},"contact":["mailto:info@test.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:16.554354663-05:00"}'
+      string: '{"id":7,"key":{"kty":"RSA","n":"tRV-Cklf3t1270t-DiOd2C3U0qZdGwWna4guV_3abMHUSS3WPf0_mvvt4lHuUrStPbip_uwetL_YMEXNGEFWRseKLRy17usaUwBN1c4R2uw50qb5coEeSoNQTS_v_qcHBD8ko8t63TTaVNjytLk3ql-xIgFuJCdedGWDtLEAdr73tWbp9n5Akm7LhsrzlWjFu5NsbnJzYtkL2ZY3ETc5gSdRLdA7oRcqpwcTXajy5GTsmwQO2U8bQIjzdzGLRGrC2_XxY_Co8r2CBnZopfFlUG3hC4rtubxM4tQvp5topb1swrSCGT7vYZ_vWUBgi0Td7X6xcw4mjSDLmH23yyXYgQ","e":"AQAB"},"contact":["mailto:info@example.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:16.554354663-05:00"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:
@@ -96,7 +96,7 @@ http_interactions:
       - '527'
     body:
       encoding: UTF-8
-      string: '{"id":7,"key":{"kty":"RSA","n":"tRV-Cklf3t1270t-DiOd2C3U0qZdGwWna4guV_3abMHUSS3WPf0_mvvt4lHuUrStPbip_uwetL_YMEXNGEFWRseKLRy17usaUwBN1c4R2uw50qb5coEeSoNQTS_v_qcHBD8ko8t63TTaVNjytLk3ql-xIgFuJCdedGWDtLEAdr73tWbp9n5Akm7LhsrzlWjFu5NsbnJzYtkL2ZY3ETc5gSdRLdA7oRcqpwcTXajy5GTsmwQO2U8bQIjzdzGLRGrC2_XxY_Co8r2CBnZopfFlUG3hC4rtubxM4tQvp5topb1swrSCGT7vYZ_vWUBgi0Td7X6xcw4mjSDLmH23yyXYgQ","e":"AQAB"},"contact":["mailto:info@test.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:16Z"}'
+      string: '{"id":7,"key":{"kty":"RSA","n":"tRV-Cklf3t1270t-DiOd2C3U0qZdGwWna4guV_3abMHUSS3WPf0_mvvt4lHuUrStPbip_uwetL_YMEXNGEFWRseKLRy17usaUwBN1c4R2uw50qb5coEeSoNQTS_v_qcHBD8ko8t63TTaVNjytLk3ql-xIgFuJCdedGWDtLEAdr73tWbp9n5Akm7LhsrzlWjFu5NsbnJzYtkL2ZY3ETc5gSdRLdA7oRcqpwcTXajy5GTsmwQO2U8bQIjzdzGLRGrC2_XxY_Co8r2CBnZopfFlUG3hC4rtubxM4tQvp5topb1swrSCGT7vYZ_vWUBgi0Td7X6xcw4mjSDLmH23yyXYgQ","e":"AQAB"},"contact":["mailto:info@example.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:16Z"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:
@@ -131,7 +131,7 @@ http_interactions:
       - '1114'
     body:
       encoding: UTF-8
-      string: '{"identifier":{"type":"dns","value":"test90.testdomain.com"},"status":"pending","expires":"2015-12-04T16:16:16.579245251-05:00","challenges":[{"type":"tls-sni-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/11","token":"oAJXJBcULZyZWhBzDW2q7NUqSgbHFMhsWFlbjwy6m18"},{"type":"dns-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/12","token":"lbfOSLoH3aKTE8pe7XG2TPBaicGZXMMP-b9MELAhW5Y"},{"type":"simpleHttp","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/13","token":"RuVBG636zeIYIbw8-_x5E5u35IFfNkfJyAz7aArFPI8","tls":true},{"type":"http-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/14","token":"eMHlDSEcX3AU4m_mlaJrYPUVcvi4MdVCf5QSOoEm8zo"},{"type":"dvsni","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/15","token":"lUng3tG8ZGndiOpPXaADDLMmQrNSY2zxroxhTgzN_U8"}],"combinations":[[3],[0],[4],[1],[2]]}'
+      string: '{"identifier":{"type":"dns","value":"test90.testexample.org"},"status":"pending","expires":"2015-12-04T16:16:16.579245251-05:00","challenges":[{"type":"tls-sni-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/11","token":"oAJXJBcULZyZWhBzDW2q7NUqSgbHFMhsWFlbjwy6m18"},{"type":"dns-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/12","token":"lbfOSLoH3aKTE8pe7XG2TPBaicGZXMMP-b9MELAhW5Y"},{"type":"simpleHttp","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/13","token":"RuVBG636zeIYIbw8-_x5E5u35IFfNkfJyAz7aArFPI8","tls":true},{"type":"http-01","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/14","token":"eMHlDSEcX3AU4m_mlaJrYPUVcvi4MdVCf5QSOoEm8zo"},{"type":"dvsni","status":"pending","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/15","token":"lUng3tG8ZGndiOpPXaADDLMmQrNSY2zxroxhTgzN_U8"}],"combinations":[[3],[0],[4],[1],[2]]}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:
@@ -236,7 +236,7 @@ http_interactions:
       - '535'
     body:
       encoding: UTF-8
-      string: '{"type":"http-01","status":"valid","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/14","token":"eMHlDSEcX3AU4m_mlaJrYPUVcvi4MdVCf5QSOoEm8zo","keyAuthorization":"eMHlDSEcX3AU4m_mlaJrYPUVcvi4MdVCf5QSOoEm8zo.l5-DPsKXUMNnZkGGx-dhhGvybszKiyb7uGJZCkRjTvI","validationRecord":[{"url":"http://test90.testdomain.com:5002/.well-known/acme-challenge/eMHlDSEcX3AU4m_mlaJrYPUVcvi4MdVCf5QSOoEm8zo","hostname":"test90.testdomain.com","port":"5002","addressesResolved":["127.0.0.1"],"addressUsed":"127.0.0.1"}]}'
+      string: '{"type":"http-01","status":"valid","uri":"http://127.0.0.1:4000/acme/challenge/PGeNnfRnY0zfzDDghQS4GmDIs20je9FIcHQUn7yqkp8/14","token":"eMHlDSEcX3AU4m_mlaJrYPUVcvi4MdVCf5QSOoEm8zo","keyAuthorization":"eMHlDSEcX3AU4m_mlaJrYPUVcvi4MdVCf5QSOoEm8zo.l5-DPsKXUMNnZkGGx-dhhGvybszKiyb7uGJZCkRjTvI","validationRecord":[{"url":"http://test90.testexample.org:5002/.well-known/acme-challenge/eMHlDSEcX3AU4m_mlaJrYPUVcvi4MdVCf5QSOoEm8zo","hostname":"test90.testexample.org","port":"5002","addressesResolved":["127.0.0.1"],"addressUsed":"127.0.0.1"}]}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:16 GMT
 - request:

--- a/spec/cassettes/register_duplicate_failure.yml
+++ b/spec/cassettes/register_duplicate_failure.yml
@@ -62,7 +62,7 @@ http_interactions:
       - '495'
     body:
       encoding: UTF-8
-      string: '{"id":3,"key":{"kty":"RSA","n":"z3IklDcZGXLpr333qKJdceRccsEKWetAMeqxDckoSlyG01VXrJiPCpK9ksM9HdnKj3Ymb8rfnBgCv_l75nJWEsvbiIwRkigTpmKLa_04uIN4D8KBFL-DUZmABgKmAFIVrtjt6gwDKhLKDM0vv9UMhgIqej3Sy5Wii1usSY0oHmFugBHQSpO9Zm7j_DcMIFfAS9ENUM9yZ2Y2FOy_3HSjKTTdCljee05FtXo9owelLRgn8S-koNq0fs7J0uT7o02uQ7c7trRHIZKeHKAcnWi6Qof99YR33yIipWqyf1Pnh4w5MWwzgyhYmufRCbD1bBCIXepVEg_lR57gic6XJD8_iw","e":"AQAB"},"contact":["mailto:mail@test.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:15.9805808-05:00"}'
+      string: '{"id":3,"key":{"kty":"RSA","n":"z3IklDcZGXLpr333qKJdceRccsEKWetAMeqxDckoSlyG01VXrJiPCpK9ksM9HdnKj3Ymb8rfnBgCv_l75nJWEsvbiIwRkigTpmKLa_04uIN4D8KBFL-DUZmABgKmAFIVrtjt6gwDKhLKDM0vv9UMhgIqej3Sy5Wii1usSY0oHmFugBHQSpO9Zm7j_DcMIFfAS9ENUM9yZ2Y2FOy_3HSjKTTdCljee05FtXo9owelLRgn8S-koNq0fs7J0uT7o02uQ7c7trRHIZKeHKAcnWi6Qof99YR33yIipWqyf1Pnh4w5MWwzgyhYmufRCbD1bBCIXepVEg_lR57gic6XJD8_iw","e":"AQAB"},"contact":["mailto:mail@example.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:15.9805808-05:00"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:15 GMT
 - request:

--- a/spec/cassettes/registration_agree_terms.yml
+++ b/spec/cassettes/registration_agree_terms.yml
@@ -62,7 +62,7 @@ http_interactions:
       - '498'
     body:
       encoding: UTF-8
-      string: '{"id":10,"key":{"kty":"RSA","n":"vu23lBZuhO4ITkYeRGOUYcL_wgxyjs2wV11vFU5PHkpl2sAEb5ydwe-tcirORpQafJg_xn76A0SWMCG474FP05OHuysEuolGyPDYhVUMWGVZV_Q4oWRkaalXGC9QL1rsq5Qk1JvdOSYQEm_zIJ-guM_Rf5cDNJIdDFMttPMuRiMHAAHNdCSO3gtYW-tB_OjJUTRqMTAbSl-C9jHxA-IXbafYiakXUFo4hsNEviw7wXk-PmvtmlNWfg7W6xDWQ56AoMEMgihiXcQSJPokkOK9eEWWFt0ZKyp3epTsSv-x6j_A2Gvz7Rmib3esjb_PveZ9tM--Ay8hQuPlZIvLhL_RfQ","e":"AQAB"},"contact":["mailto:info@test.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:17.160773036-05:00"}'
+      string: '{"id":10,"key":{"kty":"RSA","n":"vu23lBZuhO4ITkYeRGOUYcL_wgxyjs2wV11vFU5PHkpl2sAEb5ydwe-tcirORpQafJg_xn76A0SWMCG474FP05OHuysEuolGyPDYhVUMWGVZV_Q4oWRkaalXGC9QL1rsq5Qk1JvdOSYQEm_zIJ-guM_Rf5cDNJIdDFMttPMuRiMHAAHNdCSO3gtYW-tB_OjJUTRqMTAbSl-C9jHxA-IXbafYiakXUFo4hsNEviw7wXk-PmvtmlNWfg7W6xDWQ56AoMEMgihiXcQSJPokkOK9eEWWFt0ZKyp3epTsSv-x6j_A2Gvz7Rmib3esjb_PveZ9tM--Ay8hQuPlZIvLhL_RfQ","e":"AQAB"},"contact":["mailto:info@example.com"],"initialIp":"127.0.0.1","createdAt":"2015-11-27T16:16:17.160773036-05:00"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:17 GMT
 - request:
@@ -96,7 +96,7 @@ http_interactions:
       - '528'
     body:
       encoding: UTF-8
-      string: '{"id":10,"key":{"kty":"RSA","n":"vu23lBZuhO4ITkYeRGOUYcL_wgxyjs2wV11vFU5PHkpl2sAEb5ydwe-tcirORpQafJg_xn76A0SWMCG474FP05OHuysEuolGyPDYhVUMWGVZV_Q4oWRkaalXGC9QL1rsq5Qk1JvdOSYQEm_zIJ-guM_Rf5cDNJIdDFMttPMuRiMHAAHNdCSO3gtYW-tB_OjJUTRqMTAbSl-C9jHxA-IXbafYiakXUFo4hsNEviw7wXk-PmvtmlNWfg7W6xDWQ56AoMEMgihiXcQSJPokkOK9eEWWFt0ZKyp3epTsSv-x6j_A2Gvz7Rmib3esjb_PveZ9tM--Ay8hQuPlZIvLhL_RfQ","e":"AQAB"},"contact":["mailto:info@test.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:17Z"}'
+      string: '{"id":10,"key":{"kty":"RSA","n":"vu23lBZuhO4ITkYeRGOUYcL_wgxyjs2wV11vFU5PHkpl2sAEb5ydwe-tcirORpQafJg_xn76A0SWMCG474FP05OHuysEuolGyPDYhVUMWGVZV_Q4oWRkaalXGC9QL1rsq5Qk1JvdOSYQEm_zIJ-guM_Rf5cDNJIdDFMttPMuRiMHAAHNdCSO3gtYW-tB_OjJUTRqMTAbSl-C9jHxA-IXbafYiakXUFo4hsNEviw7wXk-PmvtmlNWfg7W6xDWQ56AoMEMgihiXcQSJPokkOK9eEWWFt0ZKyp3epTsSv-x6j_A2Gvz7Rmib3esjb_PveZ9tM--Ay8hQuPlZIvLhL_RfQ","e":"AQAB"},"contact":["mailto:info@example.com"],"agreement":"http://127.0.0.1:4001/terms/v1","initialIp":"127.0.0.1","createdAt":"2015-11-27T21:16:17Z"}'
     http_version: 
   recorded_at: Fri, 27 Nov 2015 21:16:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -5,13 +5,13 @@ describe Acme::Client do
 
   let(:registered_client) do
     client = Acme::Client.new(private_key: generate_private_key)
-    client.register(contact: 'mailto:mail@test.com')
+    client.register(contact: 'mailto:mail@example.com')
     client
   end
 
   let(:active_client) do
     client = Acme::Client.new(private_key: generate_private_key)
-    registration = client.register(contact: 'mailto:mail@test.com')
+    registration = client.register(contact: 'mailto:mail@example.com')
     registration.agree_terms
     client
   end
@@ -40,32 +40,32 @@ describe Acme::Client do
   context '#authorize' do
     it 'succeed', vcr: { cassette_name: 'authorize_success' } do
       expect {
-        registration = active_client.authorize(domain: 'domain.com')
+        registration = active_client.authorize(domain: 'example.org')
         expect(registration).to be_a(Acme::Resources::Authorization)
       }.to_not raise_error
     end
 
     it 'fail when the client has not yet agree to the tos', vcr: { cassette_name: 'authorize_fail_tos' } do
       expect {
-        registered_client.authorize(domain: 'domain.com')
+        registered_client.authorize(domain: 'example.org')
       }.to raise_error(Acme::Error, /Must agree to subscriber agreement before any further actions/)
     end
 
     it 'fail when the domain is not valid', vcr: { cassette_name: 'authorize_invalid_domain' } do
       expect {
-        active_client.authorize(domain: 'notadomain')
+        active_client.authorize(domain: 'notadomain.invalid')
       }.to raise_error(Acme::Error, /Error creating new authz/)
     end
   end
 
   context '#new_certificate' do
-    let(:domain) { "test#{rand(10*10)}.testdomain.com" }
+    let(:domain) { "test#{rand(10*10)}.example.net" }
     let(:private_key) { generate_private_key }
     let(:client) { Acme::Client.new(private_key: private_key) }
     let(:csr) { generate_csr(domain, generate_private_key) }
 
     before(:each) do
-      registration = client.register(contact: 'mailto:info@test.com')
+      registration = client.register(contact: 'mailto:info@example.com')
       registration.agree_terms
       authorization = client.authorize(domain: domain)
       http01 = authorization.http01

--- a/spec/http_01_spec.rb
+++ b/spec/http_01_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Acme::Resources::Challenges::HTTP01 do
   let(:http01) do
     client = Acme::Client.new(private_key: generate_private_key)
-    registration = client.register(contact: 'mailto:info@test.com')
+    registration = client.register(contact: 'mailto:info@example.com')
     registration.agree_terms
-    authorization = client.authorize(domain: "test#{rand(10*10)}.testdomain.com")
+    authorization = client.authorize(domain: "test#{rand(10*10)}.example.org")
     http01 = authorization.http01
     http01
   end

--- a/spec/registration_spec.rb
+++ b/spec/registration_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Acme::Resources::Registration do
   let(:client) { Acme::Client.new(private_key: generate_private_key) }
-  let(:registration) { client.register(contact: 'mailto:info@test.com') }
+  let(:registration) { client.register(contact: 'mailto:info@example.com') }
 
   context '#agree_terms' do
     it 'send the agreement for the terms', vcr: { cassette_name: 'registration_agree_terms' } do


### PR DESCRIPTION
Examples shouldn't refer to potentially valid domain names,
not only because of potential conflicts or no guarantees on
real world values, but also to avoid to potentially reference
undesirable content hosted on those.