### PR TITLE
Provide a convenience wrapper for CSR generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--order rand

--- a/lib/acme-client.rb
+++ b/lib/acme-client.rb
@@ -8,6 +8,7 @@ require 'digest'
 require 'forwardable'
 
 require 'acme/certificate'
+require 'acme/certificate_request'
 require 'acme/crypto'
 require 'acme/client'
 require 'acme/resources'

--- a/lib/acme/certificate.rb
+++ b/lib/acme/certificate.rb
@@ -1,13 +1,14 @@
 class Acme::Certificate
   extend Forwardable
 
-  attr_reader :x509, :x509_chain
+  attr_reader :x509, :x509_chain, :request
 
   def_delegators :x509, :to_pem, :to_der
 
-  def initialize(certificate, chain)
+  def initialize(certificate, chain, request)
     @x509 = certificate
     @x509_chain = chain
+    @request = request
   end
 
   def chain_to_pem
@@ -20,5 +21,9 @@ class Acme::Certificate
 
   def fullchain_to_pem
     x509_fullchain.map(&:to_pem).join
+  end
+
+  def common_name
+    x509.subject.to_a.find {|name, _, _| name == "CN" }[1]
   end
 end

--- a/lib/acme/certificate_request.rb
+++ b/lib/acme/certificate_request.rb
@@ -1,0 +1,113 @@
+class Acme::CertificateRequest
+  extend Forwardable
+
+  DEFAULT_KEY_LENGTH = 2048
+  DEFAULT_DIGEST = OpenSSL::Digest::SHA256
+  SUBJECT_KEYS = {
+    common_name:         "CN",
+    country_name:        "C",
+    organization_name:   "O",
+    organizational_unit: "OU",
+    state_or_province:   "ST",
+    locality_name:       "L"
+  }.freeze
+
+  SUBJECT_TYPES = {
+    "CN" => OpenSSL::ASN1::UTF8STRING,
+    "C"  => OpenSSL::ASN1::UTF8STRING,
+    "O"  => OpenSSL::ASN1::UTF8STRING,
+    "OU" => OpenSSL::ASN1::UTF8STRING,
+    "ST" => OpenSSL::ASN1::UTF8STRING,
+    "L"  => OpenSSL::ASN1::UTF8STRING
+  }.freeze
+
+  attr_reader :csr, :private_key, :common_name, :names, :subject
+
+  def_delegators :csr, :to_pem, :to_der
+
+  def initialize(common_name: nil,
+                 names: [],
+                 private_key: generate_private_key,
+                 subject: {},
+                 digest: DEFAULT_DIGEST.new)
+    raise ArgumentError.new("Digest must be a OpenSSL::Digest") unless digest.is_a?(OpenSSL::Digest)
+    @digest = digest
+
+    @private_key = private_key
+
+    @subject = normalize_subject(subject)
+    @common_name = common_name || @subject[SUBJECT_KEYS[:common_name]] || @subject[:common_name]
+
+    @names = names.to_a.dup
+    normalize_names
+
+    @subject[SUBJECT_KEYS[:common_name]] ||= @common_name
+    validate_subject
+
+    @csr = generate
+  end
+
+  private
+
+  def generate_private_key
+    OpenSSL::PKey::RSA.new(DEFAULT_KEY_LENGTH)
+  end
+
+  def normalize_subject(subject)
+    @subject = subject.each_with_object({}) {|(key, value), subject|
+      subject[SUBJECT_KEYS.fetch(key, key)] = value.to_s
+    }
+  end
+
+  def normalize_names
+    if @common_name
+      @names.unshift(@common_name) unless @names.include?(@common_name)
+    elsif @names.empty?
+      raise ArgumentError.new("No common name and no list of names given")
+    else
+      @common_name = @names.first
+    end
+  end
+
+  def validate_subject
+    extra_keys = @subject.keys - SUBJECT_KEYS.keys - SUBJECT_KEYS.values
+    unless extra_keys.empty?
+      raise ArgumentError.new("Unexpected subject attributes given: #{extra_keys.inspect}")
+    end
+
+    unless @common_name == @subject[SUBJECT_KEYS[:common_name]]
+      raise ArgumentError.new("Conflicting common name given in arguments and subject")
+    end
+  end
+
+  def generate
+    OpenSSL::X509::Request.new.tap do |csr|
+      csr.public_key = @private_key.public_key
+      csr.subject = generate_subject
+      add_extension(csr)
+      csr.sign @private_key, @digest
+    end
+  end
+
+  def generate_subject
+    OpenSSL::X509::Name.new(
+      @subject.map {|name, value|
+        [name, value, SUBJECT_TYPES[name]]
+      }
+    )
+  end
+
+  def add_extension(csr)
+    return if @names.size <= 1
+
+    extension = OpenSSL::X509::ExtensionFactory.new.create_extension(
+      "subjectAltName", @names.map {|name| "DNS:#{name}" }.join(", "), false
+    )
+    csr.add_attribute(
+      OpenSSL::X509::Attribute.new(
+        "extReq",
+        OpenSSL::ASN1::Set.new([OpenSSL::ASN1::Sequence.new([extension])])
+      )
+    )
+  end
+end

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -44,7 +44,7 @@ class Acme::Client
     }
 
     response = connection.post(@operation_endpoints.fetch('new-cert'), payload)
-    ::Acme::Certificate.new(OpenSSL::X509::Certificate.new(response.body), fetch_chain(response))
+    ::Acme::Certificate.new(OpenSSL::X509::Certificate.new(response.body), fetch_chain(response), csr)
   end
 
   def fetch_chain(response, limit=10)

--- a/spec/certificate_request_spec.rb
+++ b/spec/certificate_request_spec.rb
@@ -1,0 +1,161 @@
+require 'spec_helper'
+
+describe Acme::CertificateRequest do
+  before(:all) do
+    @test_key = generate_private_key
+  end
+
+  it "checks for a valid digest" do
+    expect {
+      Acme::CertificateRequest.new(common_name: "example.org", private_key: @test_key, digest: :not_a_digest)
+    }.to raise_error(ArgumentError, /OpenSSL::Digest/)
+  end
+
+  it "reads the common name from the subject" do
+    request = Acme::CertificateRequest.new(private_key: @test_key, subject: {common_name: "example.org"})
+
+    expect(request.common_name).to eq("example.org")
+
+    request = Acme::CertificateRequest.new(private_key: @test_key, subject: {"CN" => "example.org"})
+
+    expect(request.common_name).to eq("example.org")
+  end
+
+  it "doesn't modify the given subject" do
+    subject = {common_name: "example.org"}
+    original = subject.dup
+    Acme::CertificateRequest.new(private_key: @test_key, subject: subject)
+
+    expect(subject).to eq(original)
+  end
+
+  it "normalizes the subject to OpenSSL short names" do
+    subject = Acme::CertificateRequest::SUBJECT_KEYS.each_with_object({}) {|(key, _), subject|
+      subject[key] = "example"
+    }
+    request = Acme::CertificateRequest.new(private_key: @test_key, subject: subject)
+
+    subject = Acme::CertificateRequest::SUBJECT_KEYS.each_with_object({}) {|(_, short_name), subject|
+      subject[short_name] = "example"
+    }
+    expect(request.subject).to eq(subject)
+  end
+
+  it "sets the subject common name from the parameter" do
+    request = Acme::CertificateRequest.new(common_name: "example.org", private_key: @test_key)
+
+    expect(request.subject["CN"]).to eq("example.org")
+  end
+
+  it "doesn't modify the given names" do
+    names = %w[www.example.org example.net]
+    original = names.dup
+    request = Acme::CertificateRequest.new(common_name: "example.org", names: names, private_key: @test_key)
+
+    expect(names).to eq(original)
+  end
+
+  it "adds the common name to the names" do
+    request = Acme::CertificateRequest.new(common_name: "example.org", private_key: @test_key)
+
+    expect(request.names).to eq(%w[example.org])
+  end
+
+  it "picks a single domain as the common name" do
+    request = Acme::CertificateRequest.new(names: %w[example.org], private_key: @test_key)
+
+    expect(request.common_name).to eq("example.org")
+    expect(request.subject["CN"]).to eq("example.org")
+    expect(request.names).to eq(%w[example.org])
+  end
+
+  it "picks the common name from the names" do
+    request = Acme::CertificateRequest.new(names: %w[example.org www.example.org], private_key: @test_key)
+
+    expect(request.common_name).to eq("example.org")
+    expect(request.subject["CN"]).to eq("example.org")
+    expect(request.names).to eq(%w[example.org www.example.org])
+  end
+
+  it "expects a domain" do
+    expect {
+      Acme::CertificateRequest.new(private_key: @test_key)
+    }.to raise_error(ArgumentError, /No common name/)
+  end
+
+  it "disallows arbitrary subject keys" do
+    expect {
+      Acme::CertificateRequest.new(
+        common_name: "example.org",
+        private_key: @test_key,
+        subject: {:milk => "yes", "serialNumber" => 123}
+      )
+    }.to raise_error(ArgumentError, /Unexpected subject attributes/)
+  end
+
+  it "checks consistency of given common names" do
+    expect {
+      Acme::CertificateRequest.new(
+        common_name: "example.org",
+        private_key: @test_key,
+        subject: {common_name: "example.net"}
+      )
+    }.to raise_error(ArgumentError, /Conflicting common name/)
+
+    expect {
+      Acme::CertificateRequest.new(
+        common_name: "example.org",
+        private_key: @test_key,
+        subject: {"CN" => "example.net"}
+      )
+    }.to raise_error(ArgumentError, /Conflicting common name/)
+  end
+
+  it "assigns the public key" do
+    request = Acme::CertificateRequest.new(common_name: "example.org", private_key: @test_key)
+
+    expect(request.csr.public_key.to_der).to eq(@test_key.public_key.to_der)
+    expect(request.csr.verify(request.csr.public_key)).to be(true)
+  end
+
+  it "adds the common name to the subject" do
+    request = Acme::CertificateRequest.new(common_name: "example.org", private_key: @test_key)
+
+    subject = request.csr.subject.to_a.map {|name, value, _| [name, value] }.to_h
+    expect(subject["CN"]).to eq("example.org")
+  end
+
+  it "adds other valid attributes to the subject" do
+    subject = Acme::CertificateRequest::SUBJECT_KEYS.each_with_object({}) {|(_, short_name), subject|
+      subject[short_name] = "example"
+    }
+    request = Acme::CertificateRequest.new(private_key: @test_key, subject: subject)
+
+    csr_subject = request.csr.subject.to_a.map {|name, value, _| [name, value] }.to_h
+    expect(csr_subject).to eq(subject)
+  end
+
+  it "does not create a subjectAltName extension with a single domain" do
+    request = Acme::CertificateRequest.new(common_name: "example.org", private_key: @test_key)
+
+    expect(request.csr.attributes).to be_empty
+  end
+
+  it "creates a subjectAltName extension with multiple names" do
+    request = Acme::CertificateRequest.new(names: %w[example.org www.example.org], private_key: @test_key)
+
+    extension = request.csr.attributes.find {|attribute|
+      attribute.value.first.first.value.first.value == "subjectAltName"
+    }
+    expect(extension).not_to be_nil
+    value = extension.value.first.first.value.last.value
+    expect(value).to include("example.org")
+    expect(value).to include("www.example.org")
+  end
+
+  it "signs the request with the private key" do
+    request = Acme::CertificateRequest.new(common_name: "example.org", private_key: @test_key)
+
+    expect(request.csr.verify(@test_key.public_key)).to be(true)
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -63,6 +63,7 @@ describe Acme::Client do
     let(:private_key) { generate_private_key }
     let(:client) { Acme::Client.new(private_key: private_key) }
     let(:csr) { generate_csr(domain, generate_private_key) }
+    let(:request) { Acme::CertificateRequest.new(common_name: domain, private_key: generate_private_key) }
 
     before(:each) do
       registration = client.register(contact: 'mailto:info@example.com')
@@ -86,6 +87,21 @@ describe Acme::Client do
       }.to_not raise_error
 
       expect(certificate).to be_a(Acme::Certificate)
+      expect(certificate.common_name).to eq("test23.example.org")
+      expect(certificate.x509).to be_a(OpenSSL::X509::Certificate)
+      expect(certificate.x509_chain).not_to be_empty
+      expect(certificate.x509_chain).to contain_exactly(a_kind_of(OpenSSL::X509::Certificate), a_kind_of(OpenSSL::X509::Certificate))
+    end
+
+    it 'retrieve a new certificate successfully using a Acme::CertificateRequest', vcr: { cassette_name: 'new_certificate_success' } do
+      certificate = nil
+
+      expect {
+        certificate = client.new_certificate(request)
+      }.to_not raise_error
+
+      expect(certificate).to be_a(Acme::Certificate)
+      expect(certificate.common_name).to eq("test23.example.org")
       expect(certificate.x509).to be_a(OpenSSL::X509::Certificate)
       expect(certificate.x509_chain).not_to be_empty
       expect(certificate.x509_chain).to contain_exactly(a_kind_of(OpenSSL::X509::Certificate), a_kind_of(OpenSSL::X509::Certificate))


### PR DESCRIPTION
closes #24


Not sure about what subject attributes to support, I kept the list rather minimal for now, most CAs reject everything but the common name anyway.