### PR TITLE
add #revoke_certificate to client

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -49,6 +49,16 @@ class Acme::Client
     ::Acme::Client::Certificate.new(OpenSSL::X509::Certificate.new(response.body), fetch_chain(response), csr)
   end
 
+  def revoke_certificate(certificate)
+    payload = {
+      resource: 'revoke-cert',
+      certificate: Base64.urlsafe_encode64(certificate.to_der)
+    }
+
+    response = connection.post(@operation_endpoints.fetch('revoke-cert'), payload)
+    response.status
+  end
+
   def connection
     @connection ||= Faraday.new(@endpoint) do |configuration|
       configuration.use Acme::Client::FaradayMiddleware, client: self


### PR DESCRIPTION
Hi, I've add revoke_cert request. I'd like to revoke a certificate.

And, I think that need to ask you few questions.

- What object should this method returns?
    - F.Y.I boulder returns 200 status and empty body on success.
- Should I add spec about `#revoke_certificate` ?