### PR TITLE
Adds ruby version requirement to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ File.write("fullchain.pem", certificate.fullchain_to_pem)
 - Recovery methods are not implemented.
 - proofOfPossession-01 is not implemented.
 
+# Requirements
+
+Ruby >= 2.1
+
 ## Development
 
 All the tests use VCR to mock the interaction with the server but if you


### PR DESCRIPTION
Using required keyword arguments only works from ruby 2.1 and above...

for example in here... https://github.com/unixcharles/acme-client/blob/master/lib/acme/client.rb#L12