### PR TITLE
Reference the correct private key file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ File.write("fullchain.pem", certificate.fullchain_to_pem)
 #   :Port => 8443,
 #   :DocumentRoot => Dir.pwd,
 #   :SSLEnable => true,
-#   :SSLPrivateKey => OpenSSL::PKey::RSA.new( File.read('key.pem') ),
+#   :SSLPrivateKey => OpenSSL::PKey::RSA.new( File.read('privkey.pem') ),
 #   :SSLCertificate => OpenSSL::X509::Certificate.new( File.read('cert.pem') )); trap('INT') { s.shutdown }; s.start"
 ```
 


### PR DESCRIPTION
This is a trivial change. In the usage section you write the private key in a file called `privkey.pem`

```ruby
File.write("privkey.pem", certificate.request.private_key.to_pem)
```

but then you start the server reading from `key.pem`. It's easy to figure out what's happening if you read the error message you get from the server, however it's also an easy fix. :)
