### PR TITLE
Expose the authorization expiration timestamp

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,11 @@
 AllCops:
-  RunRailsCops: false
+  TargetRubyVersion: 2.2
   Exclude:
     - 'bin/*'
     - 'vendor/**/*'
+
+Rails:
+  Enabled: false
 
 Style/FileName:
   Exclude:
@@ -29,7 +32,10 @@ Style/AlignParameters:
 Style/FirstParameterIndentation:
   EnforcedStyle: consistent
 
-Style/TrailingComma:
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
   Enabled: false
 
 Style/StringLiterals:

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ gemspec
 
 group :development, :test do
   gem 'pry'
-  gem 'rubocop'
+  gem 'rubocop', '0.36.0'
   gem 'ruby-prof', require: false
 end

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -1,13 +1,13 @@
 require 'acme-client'
 
 class Acme::Client
-  DEFAULT_ENDPOINT = 'http://127.0.0.1:4000'
+  DEFAULT_ENDPOINT = 'http://127.0.0.1:4000'.freeze
   DIRECTORY_DEFAULT = {
     'new-authz' => '/acme/new-authz',
     'new-cert' => '/acme/new-cert',
     'new-reg' => '/acme/new-reg',
     'revoke-cert' => '/acme/revoke-cert'
-  }
+  }.freeze
 
   def initialize(private_key:, endpoint: DEFAULT_ENDPOINT, directory_uri: nil)
     @endpoint, @private_key, @directory_uri = endpoint, private_key, directory_uri

--- a/lib/acme/client/certificate_request.rb
+++ b/lib/acme/client/certificate_request.rb
@@ -55,9 +55,8 @@ class Acme::Client::CertificateRequest
   def normalize_names
     if @common_name
       @names.unshift(@common_name) unless @names.include?(@common_name)
-    elsif @names.empty?
-      raise ArgumentError, 'No common name and no list of names given'
     else
+      raise ArgumentError, 'No common name and no list of names given' if @names.empty?
       @common_name = @names.first
     end
   end

--- a/lib/acme/client/resources/authorization.rb
+++ b/lib/acme/client/resources/authorization.rb
@@ -25,7 +25,7 @@ class Acme::Client::Resources::Authorization
   end
 
   def assign_attributes(body)
-    @expires = Time.parse(body['expires']) if body.has_key? 'expires'
+    @expires = Time.iso8601(body['expires']) if body.has_key? 'expires'
     @domain = body['identifier']['value']
     @status = body['status']
   end

--- a/lib/acme/client/resources/authorization.rb
+++ b/lib/acme/client/resources/authorization.rb
@@ -25,7 +25,7 @@ class Acme::Client::Resources::Authorization
   end
 
   def assign_attributes(body)
-    @expires = Time.iso8601(body['expires']) if body.has_key? 'expires'
+    @expires = Time.iso8601(body['expires']) if body.key? 'expires'
     @domain = body['identifier']['value']
     @status = body['status']
   end

--- a/lib/acme/client/resources/authorization.rb
+++ b/lib/acme/client/resources/authorization.rb
@@ -3,7 +3,7 @@ class Acme::Client::Resources::Authorization
   DNS01 = Acme::Client::Resources::Challenges::DNS01
   TLSSNI01 = Acme::Client::Resources::Challenges::TLSSNI01
 
-  attr_reader :domain, :status, :http01, :dns01, :tls_sni01
+  attr_reader :domain, :status, :expires, :http01, :dns01, :tls_sni01
 
   def initialize(client, response)
     @client = client
@@ -25,6 +25,7 @@ class Acme::Client::Resources::Authorization
   end
 
   def assign_attributes(body)
+    @expires = Time.parse(body['expires']) if body.has_key? 'expires'
     @domain = body['identifier']['value']
     @status = body['status']
   end

--- a/lib/acme/client/version.rb
+++ b/lib/acme/client/version.rb
@@ -1,5 +1,5 @@
 module Acme
   class Client
-    VERSION = '0.2.4'
+    VERSION = '0.2.4'.freeze
   end
 end

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -10,6 +10,11 @@ describe Acme::Client::Resources::Authorization do
 
   let(:authorization) { client.authorize(domain: 'example.org') }
 
+  it 'returns the correct metadata', vcr: { cassette_name: 'authorization' } do
+    expect(authorization.expires).to be_a(Time)
+    expect(authorization.expires).to be_within(1.second).of Time.mktime(2015, 12, 14, 21, 46, 33)
+  end
+
   context '#http01' do
     it 'returns a HTTP01 object', vcr: { cassette_name: 'authorization' } do
       expect(authorization.http01).to be_a(Acme::Client::Resources::Challenges::HTTP01)

--- a/spec/support/ssl_helper.rb
+++ b/spec/support/ssl_helper.rb
@@ -40,9 +40,14 @@ module SSLHelper
 
   def generate_csr(common_name, private_key)
     request = OpenSSL::X509::Request.new
-    request.subject = OpenSSL::X509::Name.new([
-      ['CN', common_name, OpenSSL::ASN1::UTF8STRING]
-    ])
+    request.subject = OpenSSL::X509::Name.new(
+      [
+        [
+          'CN',
+          common_name,
+          OpenSSL::ASN1::UTF8STRING
+        ]
+      ])
 
     request.public_key = private_key.public_key
     request.sign(private_key, OpenSSL::Digest::SHA256.new)


### PR DESCRIPTION
The ACME server returns an optional timestamp for authorizations that signifies the expiration date of the domain authorization challenge. The time format is RFC3339 and can be parsed by Time#parse.

See: https://letsencrypt.github.io/acme-spec/
Section 5.3 - expires

Testing Done:
Updated and verified unit tests
Tested on live data with a test instance of the https://github.com/letsencrypt/boulder server

I'm currently experimenting with acme-client, and if all goes well I may have more improvements for it, but now for this is what I have.