### PR TITLE
Add ability to serialize challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,14 @@ FileUtils.mkdir_p( File.join( 'public', File.dirname( challenge.filename ) ) )
 # Then writing the file
 File.write( File.join( 'public', challenge.filename), challenge.file_content )
 
+# Optionally save the challenge for use at another time (eg: by a background job processor)
+File.write('challenge', challenge.to_h.to_json)
+
 # The challenge file can be server with a Ruby webserver such as run a webserver in another console. You may need to forward ports on your router
 #ruby -run -e httpd public -p 8080 --bind-address 0.0.0.0
 
+# Load a saved challenge. This is only required if you need to reuse a saved challenge as outlined above.
+challenge = client.challenge_from_hash(JSON.parse(File.read('challenge')))
 
 # Once you are ready to serve the confirmation request you can proceed.
 challenge.request_verification # => true

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -68,6 +68,17 @@ class Acme::Client
     end
   end
 
+  def challenge_from_hash(attributes)
+    case attributes.fetch('type')
+    when 'http-01'
+      Acme::Client::Resources::Challenges::HTTP01.new(self, attributes)
+    when 'dns-01'
+      Acme::Client::Resources::Challenges::DNS01.new(self, attributes)
+    when 'tls-sni-01'
+      Acme::Client::Resources::Challenges::TLSSNI01.new(self, attributes)
+    end
+  end
+
   private
 
   def fetch_chain(response, limit = 10)

--- a/lib/acme/client/resources/challenges/base.rb
+++ b/lib/acme/client/resources/challenges/base.rb
@@ -19,6 +19,10 @@ class Acme::Client::Resources::Challenges::Base
     response.success?
   end
 
+  def to_h
+    { 'token' => token, 'uri' => uri, 'type' => challenge_type }
+  end
+
   private
 
   def challenge_type

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -146,4 +146,45 @@ describe Acme::Client do
       expect { bad_client.revoke_certificate(certificate) }.to raise_error(Acme::Client::Error::Unauthorized)
     end
   end
+
+  context '#challenge_from_hash' do
+    let(:challenge_hash) do
+      { 'token' => 'some-token', 'uri' => '/some-uri' }
+    end
+
+    let(:client) { Acme::Client.new(private_key: 'fake-key') }
+    let(:http01) { Acme::Client::Resources::Challenges::HTTP01 }
+    let(:dns01) { Acme::Client::Resources::Challenges::DNS01 }
+    let(:tls_sni01) { Acme::Client::Resources::Challenges::TLSSNI01 }
+
+    it 'returns an HTTP01 challenge object with the specified parameters' do
+      challenge = client.challenge_from_hash(challenge_hash.merge('type' => http01::CHALLENGE_TYPE))
+
+      expect(challenge).to be_a(http01)
+      expect(challenge.uri).to eq challenge_hash['uri']
+      expect(challenge.token).to eq challenge_hash['token']
+    end
+
+    it 'returns a DNS01 challenge object with the specified parameters' do
+      challenge = client.challenge_from_hash(challenge_hash.merge('type' => dns01::CHALLENGE_TYPE))
+
+      expect(challenge).to be_a(dns01)
+      expect(challenge.uri).to eq challenge_hash['uri']
+      expect(challenge.token).to eq challenge_hash['token']
+    end
+
+    it 'returns an TLSSNI01 challenge object with the specified parameters' do
+      challenge = client.challenge_from_hash(challenge_hash.merge('type' => tls_sni01::CHALLENGE_TYPE))
+
+      expect(challenge).to be_a(tls_sni01)
+      expect(challenge.uri).to eq challenge_hash['uri']
+      expect(challenge.token).to eq challenge_hash['token']
+    end
+
+    it 'returns nil if an unsupported challenge type is provided' do
+      challenge = client.challenge_from_hash(challenge_hash.merge('type' => 'nope'))
+
+      expect(challenge).to be_nil
+    end
+  end
 end

--- a/spec/dns_01_spec.rb
+++ b/spec/dns_01_spec.rb
@@ -13,6 +13,9 @@ describe Acme::Client::Resources::Challenges::DNS01 do
     expect(dns01.record_name).to eq '_acme-challenge'
     expect(dns01.record_type).to eq 'TXT'
     expect(dns01.record_content).to be_a(String)
+    expect(dns01.to_h['token']).to eq(dns01.token)
+    expect(dns01.to_h['uri']).to eq(dns01.uri)
+    expect(dns01.to_h['type']).to eq(dns01.class::CHALLENGE_TYPE)
   end
 
   it 'successfully verify the challenge', vcr: { cassette_name: 'dns01_verify_success' } do

--- a/spec/http_01_spec.rb
+++ b/spec/http_01_spec.rb
@@ -12,6 +12,9 @@ describe Acme::Client::Resources::Challenges::HTTP01 do
   it 'returns the correct metadata', vcr: { cassette_name: 'http01_metadata' } do
     expect(http01.filename).to start_with('.well-known/acme-challenge')
     expect(http01.file_content).to be_a(String)
+    expect(http01.to_h['token']).to eq(http01.token)
+    expect(http01.to_h['uri']).to eq(http01.uri)
+    expect(http01.to_h['type']).to eq(http01.class::CHALLENGE_TYPE)
   end
 
   context '#verify' do

--- a/spec/tls_sni_01_spec.rb
+++ b/spec/tls_sni_01_spec.rb
@@ -12,6 +12,9 @@ describe Acme::Client::Resources::Challenges::TLSSNI01 do
   it 'returns the correct certificate', vcr: { cassette_name: 'tls_sni01_metadata' } do
     expect(tls_sni01.certificate).to be_a(OpenSSL::X509::Certificate)
     expect(tls_sni01.private_key).to be_a(OpenSSL::PKey::RSA)
+    expect(tls_sni01.to_h['token']).to eq(tls_sni01.token)
+    expect(tls_sni01.to_h['uri']).to eq(tls_sni01.uri)
+    expect(tls_sni01.to_h['type']).to eq(tls_sni01.class::CHALLENGE_TYPE)
   end
 
   context '#verify' do


### PR DESCRIPTION
See #50 for background.

This allows one to store a challenge for later use. For example, the challenge can be created in 1 step and then verification can be completed separately by a background job.

