### PR TITLE
Do not sign empty bodies, and set the Content-Type header on JWS signed requests

### DIFF
--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -8,7 +8,7 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
 
   def call(env)
     @env = env
-    @env.body = crypto.generate_signed_jws(header: { nonce: pop_nonce }, payload: env.body)
+    @env.body = crypto.generate_signed_jws(header: { nonce: pop_nonce }, payload: env.body) unless env.body.nil?
     @app.call(env).on_complete { |response_env| on_complete(response_env) }
   end
 

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -8,7 +8,10 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
 
   def call(env)
     @env = env
-    @env.body = crypto.generate_signed_jws(header: { nonce: pop_nonce }, payload: env.body) unless env.body.nil?
+    unless @env.body.nil?
+      @env.body = crypto.generate_signed_jws(header: { nonce: pop_nonce }, payload: env.body)
+      @env.request_headers['Content-Type'] ||= 'application/json'
+    end
     @app.call(env).on_complete { |response_env| on_complete(response_env) }
   end
 


### PR DESCRIPTION
As per section 5.1 of the ACME draft, only requests with a non-empty
body need signing.

This also stops the following warning from net/http

  Content-Type did not set; using application/x-www-form-urlencoded

when GET requests are sent with a JWS signed (but otherwise empty) body.
