### PR TITLE
Mark required Ruby version

### DIFF
--- a/acme-client.gemspec
+++ b/acme-client.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.1.0'
+
   spec.add_development_dependency 'bundler', '~> 1.6', '>= 1.6.9'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3', '>= 3.3.0'


### PR DESCRIPTION
In using the client, I noticed that it doesn't work on Ruby <2.1.0. I later realized that this is documented in the readme. This patch also adds this requirement to the gemspec.

Thanks for the gem! I'm using it in https://github.com/will-in-wi/letsencrypt-webfaction/. Works like a charm.