### PR TITLE
add url to certificate

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -46,7 +46,7 @@ class Acme::Client
     }
 
     response = connection.post(@operation_endpoints.fetch('new-cert'), payload)
-    ::Acme::Client::Certificate.new(OpenSSL::X509::Certificate.new(response.body), fetch_chain(response), csr)
+    ::Acme::Client::Certificate.new(OpenSSL::X509::Certificate.new(response.body), response.headers['location'], fetch_chain(response), csr)
   end
 
   def revoke_certificate(certificate)

--- a/lib/acme/client/certificate.rb
+++ b/lib/acme/client/certificate.rb
@@ -1,12 +1,13 @@
 class Acme::Client::Certificate
   extend Forwardable
 
-  attr_reader :x509, :x509_chain, :request, :private_key
+  attr_reader :x509, :x509_chain, :request, :private_key, :url
 
   def_delegators :x509, :to_pem, :to_der
 
-  def initialize(certificate, chain, request)
+  def initialize(certificate, url, chain, request)
     @x509 = certificate
+    @url = url
     @x509_chain = chain
     @request = request
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -91,6 +91,7 @@ describe Acme::Client do
       expect(certificate.x509).to be_a(OpenSSL::X509::Certificate)
       expect(certificate.x509_chain).not_to be_empty
       expect(certificate.x509_chain).to contain_exactly(a_kind_of(OpenSSL::X509::Certificate), a_kind_of(OpenSSL::X509::Certificate))
+      expect(certificate.url).to eq('http://127.0.0.1:4000/acme/cert/ff87f2112cf6596eddb5df39113701b1572a')
     end
 
     it 'retrieve a new certificate successfully using a CertificateRequest', vcr: { cassette_name: 'new_certificate_success' } do
@@ -106,6 +107,7 @@ describe Acme::Client do
       expect(certificate.x509_chain).not_to be_empty
       expect(certificate.x509_chain).to contain_exactly(a_kind_of(OpenSSL::X509::Certificate), a_kind_of(OpenSSL::X509::Certificate))
       expect(certificate.x509_fullchain.first).to be(certificate.x509)
+      expect(certificate.url).to eq('http://127.0.0.1:4000/acme/cert/ff87f2112cf6596eddb5df39113701b1572a')
     end
   end
 


### PR DESCRIPTION
@unixcharles 

Currently the certificate URL returned from the acme server isn't exposed anywhere. This adds it to the certificate object.