### PR TITLE
set Faraday request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ endpoint = 'https://acme-v01.api.letsencrypt.org/'
 
 # Initialize the client
 require 'acme/client'
-client = Acme::Client.new(private_key: private_key, endpoint: endpoint)
+client = Acme::Client.new(private_key: private_key, endpoint: endpoint, connection_options: { request: { open_timeout: 5, timeout: 5 } })
 
 # If the private key is not known to the server, we need to register it for the first time.
 registration = client.register(contact: 'mailto:contact@example.com')

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -9,8 +9,8 @@ class Acme::Client
     'revoke-cert' => '/acme/revoke-cert'
   }.freeze
 
-  def initialize(private_key:, endpoint: DEFAULT_ENDPOINT, directory_uri: nil)
-    @endpoint, @private_key, @directory_uri = endpoint, private_key, directory_uri
+  def initialize(private_key:, endpoint: DEFAULT_ENDPOINT, directory_uri: nil, connection_options: {})
+    @endpoint, @private_key, @directory_uri, @connection_options = endpoint, private_key, directory_uri, connection_options
     @nonces ||= []
     load_directory!
   end
@@ -62,7 +62,7 @@ class Acme::Client
   end
 
   def connection
-    @connection ||= Faraday.new(@endpoint) do |configuration|
+    @connection ||= Faraday.new(@endpoint, **@connection_options) do |configuration|
       configuration.use Acme::Client::FaradayMiddleware, client: self
       configuration.adapter Faraday.default_adapter
     end

--- a/lib/acme/client/error.rb
+++ b/lib/acme/client/error.rb
@@ -9,4 +9,5 @@ class Acme::Client::Error < StandardError
   class Acme::Tls < Acme::Client::Error; end
   class Unauthorized < Acme::Client::Error; end
   class UnknownHost < Acme::Client::Error; end
+  class Timeout < Acme::Client::Error; end
 end

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -10,6 +10,8 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
     @env = env
     @env.body = crypto.generate_signed_jws(header: { nonce: pop_nonce }, payload: env.body)
     @app.call(env).on_complete { |response_env| on_complete(response_env) }
+  rescue Faraday::TimeoutError
+    raise Acme::Client::Error::Timeout
   end
 
   def on_complete(env)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'acme/client'
 
 require 'rspec'
 require 'vcr'
+require 'webmock/rspec'
 
 require 'http_helper'
 require 'retry_helper'


### PR DESCRIPTION
@unixcharles What do you think of this? Should this be configurable? 

Currently the open / read timeout is 60 seconds if using [net/http](http://ruby-doc.org/stdlib-2.3.0/libdoc/net/http/rdoc/Net/HTTP.html#attribute-i-open_timeout). I need this to fail fast if LE is unresponsive or being slow. 