### PR TITLE
Clean up gem loading requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ private_key = OpenSSL::PKey::RSA.new(4096)
 endpoint = 'https://acme-v01.api.letsencrypt.org/'
 
 # Initialize the client
-require 'acme/client'
+require 'acme-client'
 client = Acme::Client.new(private_key: private_key, endpoint: endpoint, connection_options: { request: { open_timeout: 5, timeout: 5 } })
 
 # If the private key is not known to the server, we need to register it for the first time.

--- a/lib/acme-client.rb
+++ b/lib/acme-client.rb
@@ -1,5 +1,3 @@
-module Acme; class Client; end; end
-
 require 'faraday'
 require 'json'
 require 'json/jwt'
@@ -7,11 +5,13 @@ require 'openssl'
 require 'digest'
 require 'forwardable'
 
+module Acme; end
+
+require 'acme/client'
 require 'acme/client/certificate'
 require 'acme/client/certificate_request'
 require 'acme/client/self_sign_certificate'
 require 'acme/client/crypto'
-require 'acme/client'
 require 'acme/client/resources'
 require 'acme/client/faraday_middleware'
 require 'acme/client/error'

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -1,5 +1,3 @@
-require 'acme-client'
-
 class Acme::Client
   DEFAULT_ENDPOINT = 'http://127.0.0.1:4000'.freeze
   DIRECTORY_DEFAULT = {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift File.join(__dir__, '../lib')
 $LOAD_PATH.unshift File.join(__dir__, 'support')
 
-require 'acme/client'
+require 'acme-client'
 
 require 'rspec'
 require 'vcr'


### PR DESCRIPTION
Fix https://github.com/unixcharles/acme-client/issues/62

For some reason I wanted to be able to do both, `require 'acme-client'` and `require 'acme/client'`.

I can't recall a good reason for this. I guess just `require 'acme-client'` is fine.

I'll bump to `0.4` since this change the behaviour

cc @jhass @mac-adam-chaieb