### PR TITLE
Adds RateLimited error class.

### DIFF
--- a/lib/acme/client/error.rb
+++ b/lib/acme/client/error.rb
@@ -10,4 +10,5 @@ class Acme::Client::Error < StandardError
   class Unauthorized < Acme::Client::Error; end
   class UnknownHost < Acme::Client::Error; end
   class Timeout < Acme::Client::Error; end
+  class RateLimited < Acme::Client::Error; end
 end


### PR DESCRIPTION
"rateLimited" is an error code received when a client has hit a rate limit[0]. I am using this gem in a project and it would be nice to look for this specific error rather than having it thrown as the more generic Acme::Client::Error and then matching on the detail.

[0] https://ietf-wg-acme.github.io/acme/#errors