### PR TITLE
[WIP] Adds rejected identifier error

### DIFF
--- a/lib/acme/client/error.rb
+++ b/lib/acme/client/error.rb
@@ -11,4 +11,5 @@ class Acme::Client::Error < StandardError
   class UnknownHost < Acme::Client::Error; end
   class Timeout < Acme::Client::Error; end
   class RateLimited < Acme::Client::Error; end
+  class RejectedIdentifier < Acme::Client::Error; end
 end


### PR DESCRIPTION
__Goal__

Add the new `rejected identifier` (no yet available) to this implementation of the acme protocol.

__Waiting for__

Protocol : https://github.com/ietf-wg-acme/acme/pull/142
Server : https://github.com/letsencrypt/boulder/pull/1944