### PR TITLE
Add new unsupportedIdentifier error from acme protocol

### DIFF
--- a/lib/acme/client/error.rb
+++ b/lib/acme/client/error.rb
@@ -12,4 +12,5 @@ class Acme::Client::Error < StandardError
   class Timeout < Acme::Client::Error; end
   class RateLimited < Acme::Client::Error; end
   class RejectedIdentifier < Acme::Client::Error; end
+  class UnsupportedIdentifier < Acme::Client::Error; end
 end


### PR DESCRIPTION
__Goal__

Add the new unsupportedIdentifier error from the acme protocol.

__Waiting for__
Server : https://github.com/letsencrypt/boulder/pull/1944
Protocol : https://github.com/ietf-wg-acme/acme/pull/143