### PR TITLE
Make challenge_from_hash more strict with the arguments it receive

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -66,7 +66,12 @@ class Acme::Client
     end
   end
 
-  def challenge_from_hash(attributes)
+  def challenge_from_hash(arguments)
+    attributes = arguments.to_h
+    %w(type uri token).each do |key|
+      raise ArgumentError, "missing key: #{key}" unless attributes.key?(key)
+    end
+
     case attributes.fetch('type')
     when 'http-01'
       Acme::Client::Resources::Challenges::HTTP01.new(self, attributes)
@@ -74,6 +79,8 @@ class Acme::Client
       Acme::Client::Resources::Challenges::DNS01.new(self, attributes)
     when 'tls-sni-01'
       Acme::Client::Resources::Challenges::TLSSNI01.new(self, attributes)
+    else
+      raise 'Unsupported resource type'
     end
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -206,9 +206,9 @@ describe Acme::Client do
     end
 
     it 'returns nil if an unsupported challenge type is provided' do
-      challenge = client.challenge_from_hash(challenge_hash.merge('type' => 'nope'))
-
-      expect(challenge).to be_nil
+      expect {
+        client.challenge_from_hash(challenge_hash.merge('type' => 'nope'))
+      }.to raise_error(RuntimeError, 'Unsupported resource type')
     end
   end
 end


### PR DESCRIPTION
I had `KeyError: key not found: :type` exception pop up in my stack down stream because I was passing unexpected `nil` to `#challenge_from_hash`.

Its not nice when generic error pop  from your dependencies.

I modified the method interface so that it return clear in errors message in those cases.

cc @maxboisvert @jhass 