### PR TITLE
allow to require gem as: require 'acme/client'

### DIFF
--- a/lib/acme-client.rb
+++ b/lib/acme-client.rb
@@ -1,5 +1,5 @@
 # This file lives here for backward compatibility only and should be deprecated soon
-# gem named acme-client should be required as 
+# gem named acme-client should be required as
 # require 'acme/client'
 
 require 'faraday'

--- a/lib/acme-client.rb
+++ b/lib/acme-client.rb
@@ -1,3 +1,7 @@
+# This file lives here for backward compatibility only and should be deprecated soon
+# gem named acme-client should be required as 
+# require 'acme/client'
+
 require 'faraday'
 require 'json'
 require 'json/jwt'

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -1,3 +1,21 @@
+require 'faraday'
+require 'json'
+require 'json/jwt'
+require 'openssl'
+require 'digest'
+require 'forwardable'
+
+module Acme; end
+class Acme::Client; end
+
+require 'acme/client/certificate'
+require 'acme/client/certificate_request'
+require 'acme/client/self_sign_certificate'
+require 'acme/client/crypto'
+require 'acme/client/resources'
+require 'acme/client/faraday_middleware'
+require 'acme/client/error'
+
 class Acme::Client
   DEFAULT_ENDPOINT = 'http://127.0.0.1:4000'.freeze
   DIRECTORY_DEFAULT = {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift File.join(__dir__, '../lib')
 $LOAD_PATH.unshift File.join(__dir__, 'support')
 
-require 'acme-client'
+require 'acme/client'
 
 require 'rspec'
 require 'vcr'

--- a/spec/support/ssl_helper.rb
+++ b/spec/support/ssl_helper.rb
@@ -47,7 +47,8 @@ module SSLHelper
           common_name,
           OpenSSL::ASN1::UTF8STRING
         ]
-      ])
+      ]
+    )
 
     request.public_key = private_key.public_key
     request.sign(private_key, OpenSSL::Digest::SHA256.new)


### PR DESCRIPTION
it's kind of standard according to http://guides.rubygems.org/name-your-gem/