### PR TITLE
Use const_defined? over qualified_const_defined?

### DIFF
--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -50,7 +50,7 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
   end
 
   def error_class
-    if error_name.present? && Acme::Client::Error.qualified_const_defined?(error_name)
+    if error_name.present? && Acme::Client::Error.const_defined?(error_name)
       "Acme::Client::Error::#{error_name}".constantize
     else
       Acme::Client::Error


### PR DESCRIPTION
`qualified_const_defined?` is defined in activesupport and also deprecated.

`rake spec` was throwing up a lot of deprecation warnings:
```
Acme::Client
  #new_certificate
    retrieve a new certificate successfully using a CertificateRequest
    retrieve a new certificate successfully
  #revoke_certificate
    revoke a certificate successfully with the certificate key
    revoke a certificate successfully with the account key
DEPRECATION WARNING: Module#qualified_const_defined? is deprecated in favour of the builtin Module#const_defined? and will be removed in Rails 5.1. (called from error_class at /home/nh/Src/acme-client/lib/acme/client/faraday_middleware.rb:53)
    revoke a certificate fail when using an unknown key
  #authorize
DEPRECATION WARNING: Module#qualified_const_defined? is deprecated in favour of the builtin Module#const_defined? and will be removed in Rails 5.1. (called from error_class at /home/nh/Src/acme-client/lib/acme/client/faraday_middleware.rb:53)
    fail when the domain is not valid
DEPRECATION WARNING: Module#qualified_const_defined? is deprecated in favour of the builtin Module#const_defined? and will be removed in Rails 5.1. (called from error_class at /home/nh/Src/acme-client/lib/acme/client/faraday_middleware.rb:53)
    fail when the client has not yet agree to the tos
    fail when the client receive an error without a type
    succeed
  #challenge_from_hash
    returns an HTTP01 challenge object with the specified parameters
    returns nil if an unsupported challenge type is provided
    returns a DNS01 challenge object with the specified parameters
    returns an TLSSNI01 challenge object with the specified parameters
  #register
DEPRECATION WARNING: Module#qualified_const_defined? is deprecated in favour of the builtin Module#const_defined? and will be removed in Rails 5.1. (called from error_class at /home/nh/Src/acme-client/lib/acme/client/faraday_middleware.rb:53)
    fail to register a key that is already registered
DEPRECATION WARNING: Module#qualified_const_defined? is deprecated in favour of the builtin Module#const_defined? and will be removed in Rails 5.1. (called from error_class at /home/nh/Src/acme-client/lib/acme/client/faraday_middleware.rb:53)
    fail to register with an invalid contact
    register successfully
  generic errors
    raises on error with a non jose+json body
  connection_options
    fails with a timeout
    passes the connection options to faraday
```