### PR TITLE
Drop json-jwt

### DIFF
--- a/acme-client.gemspec
+++ b/acme-client.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 1.21', '>= 1.21.0'
 
   spec.add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.1'
-  spec.add_runtime_dependency 'json-jwt', '~> 1.2', '>= 1.2.3'
 end

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'json'
 require 'json/jwt'

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -2,10 +2,10 @@
 
 require 'faraday'
 require 'json'
-require 'json/jwt'
 require 'openssl'
 require 'digest'
 require 'forwardable'
+require 'base64'
 
 module Acme; end
 class Acme::Client; end

--- a/lib/acme/client/crypto.rb
+++ b/lib/acme/client/crypto.rb
@@ -6,26 +6,91 @@ class Acme::Client::Crypto
   end
 
   def generate_signed_jws(header:, payload:)
-    jwt = JSON::JWT.new(payload || {})
-    jwt.header.merge!(header || {})
-    jwt.header[:jwk] = jwk
-    jws = jwt.sign(private_key, :RS256)
-    jws.to_json(syntax: :flattened)
+    header = { typ: 'JWT', alg: jws_alg, jwk: jwk }.merge(header)
+
+    encoded_header = urlsafe_base64(header.to_json)
+    encoded_payload = urlsafe_base64(payload.to_json)
+    signature_data = "#{encoded_header}.#{encoded_payload}"
+
+    signature = private_key.sign digest, signature_data
+    encoded_signature = urlsafe_base64(signature)
+
+    {
+      protected: encoded_header,
+      payload: encoded_payload,
+      signature: encoded_signature
+    }.to_json
   end
 
   def thumbprint
-    jwk.thumbprint
+    urlsafe_base64 digest.digest(jwk.to_json)
   end
 
   def digest
     OpenSSL::Digest::SHA256.new
   end
 
+  def urlsafe_base64(data)
+    Base64.urlsafe_encode64(data).sub(/[\s=]*\z/, '')
+  end
+
   private
 
-  def jwk
-    @jwk ||= JSON::JWK.new(public_key)
+  def jws_alg
+    { 'RSA' => 'RS256', 'EC' => 'ES256' }.fetch(jwk[:kty])
   end
+
+  def jwk
+    @jwk ||= case private_key
+             when OpenSSL::PKey::RSA
+               rsa_jwk
+             when OpenSSL::PKey::EC
+               ec_jwk
+             else
+               raise ArgumentError, "Can't handle #{private_key} as private key, only OpenSSL::PKey::RSA and OpenSSL::PKey::EC"
+    end
+  end
+
+  def rsa_jwk
+    {
+      e: urlsafe_base64(public_key.e.to_s(2)),
+      kty: 'RSA',
+      n: urlsafe_base64(public_key.n.to_s(2))
+    }
+  end
+
+  def ec_jwk
+    {
+      crv: curve_name,
+      kty: 'EC',
+      x: urlsafe_base64(coordinates[:x].to_s(2)),
+      y: urlsafe_base64(coordinates[:y].to_s(2))
+    }
+  end
+
+  def curve_name
+    {
+      'prime256v1' => 'P-256',
+      'secp384r1' => 'P-384',
+      'secp521r1' => 'P-521'
+    }.fetch(private_key.group.curve_name) { raise ArgumentError, 'Unknown EC curve' }
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def coordinates
+    @coordinates ||= begin
+      hex = public_key.to_bn.to_s(16)
+      data_len = hex.length - 2
+      hex_x = hex[2, data_len / 2]
+      hex_y = hex[2 + data_len / 2, data_len / 2]
+
+      {
+        x: OpenSSL::BN.new([hex_x].pack('H*'), 2),
+        y: OpenSSL::BN.new([hex_y].pack('H*'), 2)
+      }
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
 
   def public_key
     @public_key ||= private_key.public_key

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -50,8 +50,8 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
   end
 
   def error_class
-    if error_name.present? && Acme::Client::Error.const_defined?(error_name)
-      "Acme::Client::Error::#{error_name}".constantize
+    if error_name && !error_name.empty? && Acme::Client::Error.const_defined?(error_name)
+      Object.const_get("Acme::Client::Error::#{error_name}")
     else
       Acme::Client::Error
     end
@@ -62,7 +62,7 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
       return unless env.body.is_a?(Hash)
       return unless env.body.key?('type')
 
-      env.body['type'].gsub('urn:acme:error:', '').classify
+      env.body['type'].gsub('urn:acme:error:', '').split(/[_-]/).map(&:capitalize).join
     end
   end
 

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Acme::Client::FaradayMiddleware < Faraday::Middleware
   attr_reader :env, :response, :client
 

--- a/lib/acme/client/resources/challenges/dns01.rb
+++ b/lib/acme/client/resources/challenges/dns01.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Acme::Client::Resources::Challenges::DNS01 < Acme::Client::Resources::Challenges::Base
   CHALLENGE_TYPE = 'dns-01'.freeze
   RECORD_NAME = '_acme-challenge'.freeze

--- a/lib/acme/client/resources/challenges/dns01.rb
+++ b/lib/acme/client/resources/challenges/dns01.rb
@@ -14,6 +14,6 @@ class Acme::Client::Resources::Challenges::DNS01 < Acme::Client::Resources::Chal
   end
 
   def record_content
-    Base64.urlsafe_encode64(crypto.digest.digest(authorization_key)).sub(/[\s=]*\z/, '')
+    crypto.urlsafe_base64(crypto.digest.digest(authorization_key))
   end
 end

--- a/lib/acme/client/resources/challenges/http01.rb
+++ b/lib/acme/client/resources/challenges/http01.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Acme::Client::Resources::Challenges::HTTP01 < Acme::Client::Resources::Challenges::Base
   CHALLENGE_TYPE = 'http-01'.freeze
   CONTENT_TYPE = 'text/plain'.freeze

--- a/lib/acme/client/resources/challenges/tls_sni01.rb
+++ b/lib/acme/client/resources/challenges/tls_sni01.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Acme::Client::Resources::Challenges::TLSSNI01 < Acme::Client::Resources::Challenges::Base
   CHALLENGE_TYPE = 'tls-sni-01'.freeze
 

--- a/lib/acme/client/version.rb
+++ b/lib/acme/client/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Acme
   class Client
     VERSION = '0.3.7'.freeze

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -12,7 +12,7 @@ describe Acme::Client::Resources::Authorization do
 
   it 'returns the correct metadata', vcr: { cassette_name: 'authorization' } do
     expect(authorization.expires).to be_a(Time)
-    expect(authorization.expires).to be_within(1.second).of Time.gm(2015, 12, 14, 21, 46, 33)
+    expect(authorization.expires).to be_within(1).of Time.gm(2015, 12, 14, 21, 46, 33)
   end
 
   context '#http01' do

--- a/spec/crypto_spec.rb
+++ b/spec/crypto_spec.rb
@@ -11,9 +11,15 @@ describe Acme::Client::Crypto do
   context '#generate_signed_jws' do
     it 'signs the data' do
       signed_jws = crypto.generate_signed_jws(header: { 'a-header' => 'header-value' }, payload: { 'some' => 'data' })
-      decoded_jwt = JSON::JWT.decode(JSON.load(signed_jws), private_key.public_key)
-      expect(decoded_jwt).to include('some' => 'data')
-      expect(decoded_jwt.header).to include('a-header' => 'header-value')
+      jws = JSON.parse(signed_jws)
+      header = JSON.parse(Base64.decode64(jws['protected']))
+      payload = JSON.parse(Base64.decode64(jws['payload']))
+
+      expect(header).to include('a-header' => 'header-value')
+      expect(header['typ']).to eq('JWT')
+      expect(header['alg']).to eq('RS256')
+      expect(header['jwk']['kty']).to eq('RSA')
+      expect(payload).to include('some' => 'data')
     end
   end
 end


### PR DESCRIPTION
Fixes #75 closes #68 closes #33 

I didn't rerecord the cassettes but I manually verified that everything still works. VCR by default matches only against the request method and URI, matching against the body is rather difficult for us due to non-deterministic key usage and random hostnames in the specs, so there's no real benefit to rerecording the cassettes here.

The implementation is doing just what we need, not anything more. Still it should produce identical results to json-jwt for our usecases.