### PR TITLE
Require time stdlib

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -6,6 +6,7 @@ require 'openssl'
 require 'digest'
 require 'forwardable'
 require 'base64'
+require 'time'
 
 module Acme; end
 class Acme::Client; end


### PR DESCRIPTION
https://github.com/unixcharles/acme-client/blob/92debc00c5736813f97a6012ca7fdefeee765236/lib/acme/client/resources/authorization.rb#L28-L28

`Time.iso8601` is only available after requiring the standard library. Most client apps will do this somewhere explicitly or implicitly through one of  their other dependencies, but since we make use of it we should do declare it explicitly.