### PR TITLE
Set the X509 version of the self-signed certificate

### DIFF
--- a/lib/acme/client/self_sign_certificate.rb
+++ b/lib/acme/client/self_sign_certificate.rb
@@ -47,6 +47,7 @@ class Acme::Client::SelfSignCertificate
     certificate.not_before = not_before
     certificate.not_after = not_after
     certificate.public_key = private_key.public_key
+    certificate.version = 2
     certificate
   end
 

--- a/spec/self_sign_certificate_spec.rb
+++ b/spec/self_sign_certificate_spec.rb
@@ -13,4 +13,10 @@ describe Acme::Client::SelfSignCertificate do
     expect(self_sign_certificate.certificate).to be_a(OpenSSL::X509::Certificate)
     expect(self_sign_certificate.private_key).to be(private_key)
   end
+
+  it 'sets the certificates version' do
+    private_key = generate_private_key
+    self_sign_certificate = Acme::Client::SelfSignCertificate.new(private_key: private_key, subject_alt_names: ['test.example.org'])
+    expect(self_sign_certificate.certificate.version).to eql(2)
+  end
 end


### PR DESCRIPTION
This is a PR to fix https://github.com/unixcharles/acme-client/issues/97

Original boulder issue was https://github.com/letsencrypt/boulder/issues/2124