### PR TITLE
Allow query the endpoint of the client object

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -35,7 +35,7 @@ class Acme::Client
     load_directory!
   end
 
-  attr_reader :private_key, :nonces, :operation_endpoints
+  attr_reader :private_key, :nonces, :endpoint, :directory_uri, :operation_endpoints
 
   def register(contact:)
     payload = {


### PR DESCRIPTION
It would be awful handy to ask the client object which endpoint it was configured with when reporting errors, writing logs, etc.