### PR TITLE
Set serial number of self-signed certificate

### DIFF
--- a/lib/acme/client/self_sign_certificate.rb
+++ b/lib/acme/client/self_sign_certificate.rb
@@ -48,6 +48,7 @@ class Acme::Client::SelfSignCertificate
     certificate.not_after = not_after
     certificate.public_key = private_key.public_key
     certificate.version = 2
+    certificate.serial = 1
     certificate
   end
 

--- a/spec/self_sign_certificate_spec.rb
+++ b/spec/self_sign_certificate_spec.rb
@@ -19,4 +19,10 @@ describe Acme::Client::SelfSignCertificate do
     self_sign_certificate = Acme::Client::SelfSignCertificate.new(private_key: private_key, subject_alt_names: ['test.example.org'])
     expect(self_sign_certificate.certificate.version).to eql(2)
   end
+
+  it 'sets the certificates serial number' do
+    private_key = generate_private_key
+    self_sign_certificate = Acme::Client::SelfSignCertificate.new(private_key: private_key, subject_alt_names: ['test.example.org'])
+    expect(self_sign_certificate.certificate.serial).to eql(1)
+  end
 end


### PR DESCRIPTION
Following up on #97 the serial number must be set, too.

This pull request adds a static serial number.