### PR TITLE
OpenSSL::PKey::EC are broken

### DIFF
--- a/lib/acme/client/certificate_request.rb
+++ b/lib/acme/client/certificate_request.rb
@@ -79,7 +79,7 @@ class Acme::Client::CertificateRequest
 
   def generate
     OpenSSL::X509::Request.new.tap do |csr|
-      csr.public_key = @private_key.public_key
+      csr.public_key = @private_key
       csr.subject = generate_subject
       csr.version = 2
       add_extension(csr)

--- a/spec/certificate_request_spec.rb
+++ b/spec/certificate_request_spec.rb
@@ -146,6 +146,7 @@ describe Acme::Client::CertificateRequest do
 
   it 'supports ECDSA keys' do
     ec_key = OpenSSL::PKey::EC.new('secp384r1')
+    ec_key.generate_key
     request = Acme::Client::CertificateRequest.new(common_name: 'example.org', private_key: ec_key)
 
     expect(request.csr.verify(ec_key)).to be_true

--- a/spec/certificate_request_spec.rb
+++ b/spec/certificate_request_spec.rb
@@ -143,4 +143,11 @@ describe Acme::Client::CertificateRequest do
 
     expect(request.csr.verify(test_key.public_key)).to be(true)
   end
+
+  it 'supports ECDSA keys' do
+    ec_key = OpenSSL::PKey::EC.new('secp384r1')
+    request = Acme::Client::CertificateRequest.new(common_name: 'example.org', private_key: ec_key)
+
+    expect(request.csr.verify(ec_key)).to be_true
+  end
 end


### PR DESCRIPTION
Attempt to monkey patch `OpenSSL::PKey::EC` into a working state.