### PR TITLE
Fix error_name in faraday_middleware.rb

### DIFF
--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -69,7 +69,7 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
   end
 
   def error_type_to_klass(type)
-    type.gsub('urn:acme:error:', '').split(/[_-]/).map { |type_part| type_part[0].upcase + type_part[1..-1] }.join
+    type.gsub('urn:acme:error:', '').split(/[_-]/).sub(/^./) { |c| c.upcase }.join
   end
 
   def decode_body

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -69,7 +69,7 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
   end
 
   def error_type_to_klass(type)
-    type.gsub('urn:acme:error:', '').split(/[_-]/).sub(/^./) { |c| c.upcase }.join
+    type.gsub('urn:acme:error:', '').split(/[_-]/).map { |type_part| type_part[0].upcase + type_part[1..-1] }.join
   end
 
   def decode_body

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -64,8 +64,12 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
       return unless env.body.is_a?(Hash)
       return unless env.body.key?('type')
 
-      env.body['type'].gsub('urn:acme:error:', '').split(/[_-]/).map {|type| type[0].upcase + type[1..-1] }.join
+      error_type_to_name env.body['type']
     end
+  end
+
+  def error_type_to_name(type)
+    type.gsub('urn:acme:error:', '').split(/[_-]/).map { |type| type[0].upcase + type[1..-1] }.join
   end
 
   def decode_body

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -64,7 +64,7 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
       return unless env.body.is_a?(Hash)
       return unless env.body.key?('type')
 
-      env.body['type'].gsub('urn:acme:error:', '').split(/[_-]/).map(&:capitalize).join
+      env.body['type'].gsub('urn:acme:error:', '').split(/[_-]/).map {|type| type[0].upcase + type[1..-1] }.join
     end
   end
 

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -64,12 +64,12 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
       return unless env.body.is_a?(Hash)
       return unless env.body.key?('type')
 
-      error_type_to_name env.body['type']
+      error_type_to_klass env.body['type']
     end
   end
 
-  def error_type_to_name(type)
-    type.gsub('urn:acme:error:', '').split(/[_-]/).map { |type| type[0].upcase + type[1..-1] }.join
+  def error_type_to_klass(type)
+    type.gsub('urn:acme:error:', '').split(/[_-]/).map { |type_part| type_part[0].upcase + type_part[1..-1] }.join
   end
 
   def decode_body


### PR DESCRIPTION
Due to the way error_name works, two word errors won't be instantiated when talking to ACME servers conforming to the spec.

This PR corrects the instantiation of errors issue I reported in #115 by modifying `error_name` to upcase the first character of error types and leave the rest as-is - `String.capitalize` upcases the first character and downcases the rest.

Fixes #115 