### PR TITLE
[WIP] register with an ECDSA account key

### DIFF
--- a/lib/acme/client/crypto.rb
+++ b/lib/acme/client/crypto.rb
@@ -2,7 +2,12 @@ class Acme::Client::Crypto
   attr_reader :private_key
 
   def initialize(private_key)
-    @private_key = private_key
+    if private_key.is_a?(OpenSSL::PKey::EC) && RbConfig::CONFIG['MAJOR'] == '2' &&
+       RbConfig::CONFIG['MINOR'].to_i < 4
+      @private_key = Acme::Client::CertificateRequest::ECKeyPatch.new(private_key)
+    else
+      @private_key = private_key
+    end
   end
 
   def generate_signed_jws(header:, payload:)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Acme::Client do
   let(:connection_options) { {} }
   let(:unregistered_client) { Acme::Client.new(private_key: generate_private_key, connection_options: connection_options) }
+  let(:unregistered_client_ecdsa) { Acme::Client.new(private_key: generate_ecdsa_private_key, connection_options: connection_options) }
 
   let(:registered_client) do
     client = Acme::Client.new(private_key: generate_private_key)
@@ -53,6 +54,13 @@ describe Acme::Client do
     it 'register successfully', vcr: { cassette_name: 'register_success' } do
       expect {
         registration = unregistered_client.register(contact: %w(mailto:cert-admin@example.com tel:+15145552222))
+        expect(registration).to be_a(Acme::Client::Resources::Registration)
+      }.to_not raise_error
+    end
+
+    it 'register successfully with a ECDSA key', vcr: { cassette_name: 'register_success_ecdsa' } do
+      expect {
+        registration = unregistered_client_ecdsa.register(contact: %w(mailto:cert-admin@example.com tel:+15145552222))
         expect(registration).to be_a(Acme::Client::Resources::Registration)
       }.to_not raise_error
     end

--- a/spec/support/ssl_helper.rb
+++ b/spec/support/ssl_helper.rb
@@ -38,6 +38,12 @@ module SSLHelper
     KEYSTASH.next
   end
 
+  def generate_ecdsa_private_key
+    ec_key = OpenSSL::PKey::EC.new('prime256v1')
+    ec_key.generate_key
+    ec_key
+  end
+
   def generate_csr(common_name, private_key)
     request = OpenSSL::X509::Request.new
     request.subject = OpenSSL::X509::Name.new(


### PR DESCRIPTION
From #117.
This PR updates `Acme::Client::Crypto` to handle `OpenSSL::PKey::EC` private keys and adds a spec registering with an ECDSA account key.

This spec ends with a `Acme::Client::Error::Malformed` exception:
```
1) Acme::Client#register register successfully with a ECDSA key
     Failure/Error:
       expect {
         registration = unregistered_client_ecdsa.register(contact: %w(mailto:cert-admin@example.com tel:+15145552222))
         expect(registration).to be_a(Acme::Client::Resources::Registration)
       }.to_not raise_error
     
       expected no Exception, got #<Acme::Client::Error::Malformed: JWS verification error> with backtrace:
         # ./lib/acme/client/faraday_middleware.rb:43:in `raise_on_error!'
         # ./lib/acme/client/faraday_middleware.rb:33:in `on_complete'
         # ./lib/acme/client/faraday_middleware.rb:18:in `block in call'
         # ./vendor/bundle/ruby/2.3.0/gems/faraday-0.10.0/lib/faraday/response.rb:61:in `on_complete'
         # ./lib/acme/client/faraday_middleware.rb:18:in `call'
         # ./vendor/bundle/ruby/2.3.0/gems/faraday-0.10.0/lib/faraday/rack_builder.rb:139:in `build_response'
         # ./vendor/bundle/ruby/2.3.0/gems/faraday-0.10.0/lib/faraday/connection.rb:377:in `run_request'
         # ./vendor/bundle/ruby/2.3.0/gems/faraday-0.10.0/lib/faraday/connection.rb:177:in `post'
         # ./lib/acme/client.rb:45:in `register'
         # ./spec/client_spec.rb:63:in `block (4 levels) in <top (required)>'
         # ./spec/client_spec.rb:62:in `block (3 levels) in <top (required)>'
     # ./spec/client_spec.rb:62:in `block (3 levels) in <top (required)>'
```