### PR TITLE
Do not cache error type

### DIFF
--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -60,12 +60,10 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
   end
 
   def error_name
-    @error_name ||= begin
-      return unless env.body.is_a?(Hash)
-      return unless env.body.key?('type')
+    return unless env.body.is_a?(Hash)
+    return unless env.body.key?('type')
 
-      error_type_to_klass env.body['type']
-    end
+    error_type_to_klass env.body['type']
   end
 
   def error_type_to_klass(type)


### PR DESCRIPTION
acme-client reports wrong exceptions from the second error response
because Faraday middleware is re-used.

```ruby
client = Acme::Client.new(...)
begin
  client.new_certificate(...)
rescue Acme::Client::Error::Unauthorized
  # When #authorize fails due to some reason, the exception is always
  # set to Acme::Client::Error::Unauthorized wrongly.
  client.authorize(...)
end
```