### PR TITLE
Implement Challenges::Base#[]

### DIFF
--- a/lib/acme/client/resources/challenges/base.rb
+++ b/lib/acme/client/resources/challenges/base.rb
@@ -8,6 +8,10 @@ class Acme::Client::Resources::Challenges::Base
     assign_attributes(arguments)
   end
 
+  def [](key)
+    to_h[key]
+  end
+
   def challenge_type
     self.class::CHALLENGE_TYPE
   end


### PR DESCRIPTION
`Acme::Client::Resources::Challenges.new` may return a Hash instead of `Challenges::*` when it encountered unsupported challenge type.

When an user is iterating `authz#challenges`, they have to check a class of an element in prior to use.

Checking `challenge#challenge_type` is sometime useful than checking `challenge#class` when an user has a support of additional challenge_type which are uncovered in this gem.

(And I failed here... https://github.com/sorah/acmesmith/blob/5845dbadd7e9a1ad2ebd4731304d8f59b111ae68/lib/acmesmith/client.rb#L205 )