### PR TITLE
Faraday middleware setting body on GET requests

### DIFF
--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -19,7 +19,7 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
     if @env.method != :get
       @env.body = client.jwk.jws(header: jws_header, payload: env.body)
     end
-    
+
     @app.call(env).on_complete { |response_env| on_complete(response_env) }
   rescue Faraday::TimeoutError, Faraday::ConnectionFailed
     raise Acme::Client::Error::Timeout

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -16,7 +16,10 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
     @env[:request_headers]['User-Agent'] = Acme::Client::USER_AGENT
     @env[:request_headers]['Content-Type'] = CONTENT_TYPE
 
-    @env.body = client.jwk.jws(header: jws_header, payload: env.body)
+    if @env.method != :get
+      @env.body = client.jwk.jws(header: jws_header, payload: env.body)
+    end
+    
     @app.call(env).on_complete { |response_env| on_complete(response_env) }
   rescue Faraday::TimeoutError, Faraday::ConnectionFailed
     raise Acme::Client::Error::Timeout


### PR DESCRIPTION
(was unsure whether to open a Pull request or an issue, so apologies if it's the wrong type of thing)

On Windows 10, with Acme Client 2.0.2 and Faraday 0.15.1, I noticed that many GET requests send their JSON web signature in the body.

This tends to break the underlying connection to the letsencrypt servers, but only occasionally.

Here's a raw request from Fiddler:
GET https://acme-staging-v02.api.letsencrypt.org/acme/cert/{scrubbed} HTTP/1.1
User-Agent: Acme::Client v2.0.2 (https://github.com/unixcharles/acme-client)
Accept: application/pem-certificate-chain
Content-Type: application/jose+json
Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
Connection: close
Host: acme-staging-v02.api.letsencrypt.org
Content-Length: 1936

{"protected":"{scrubbed}","payload":"{scrubbed}","signature":"{scrubbed}"}

Based on this behaviour I would have expected a body on the HEAD requests as well, but that doesn't seem to happen.