### PR TITLE
Faraday: Retry BadNonce errors at the connection level.

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -280,6 +280,12 @@ class Acme::Client
 
   def new_connection(endpoint:)
     Faraday.new(endpoint, **@connection_options) do |configuration|
+      configuration.request(:retry, max: 10,
+                            interval: 0.05,
+                            interval_randomness: 0.5,
+                            backoff_factor: 2,
+                            methods: Faraday::Connection::METHODS,
+                            exceptions: [Acme::Client::Error::BadNonce])
       yield(configuration) if block_given?
       configuration.adapter Faraday.default_adapter
     end

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -281,12 +281,15 @@ class Acme::Client
 
   def new_connection(endpoint:)
     Faraday.new(endpoint, **@connection_options) do |configuration|
-      configuration.request(:retry, max: @bad_nonce_retry,
-                            interval: 0.05,
-                            interval_randomness: 0.5,
-                            backoff_factor: 2,
-                            methods: Faraday::Connection::METHODS,
-                            exceptions: [Acme::Client::Error::BadNonce]) if @bad_nonce_retry > 0
+      if @bad_nonce_retry > 0
+      configuration.request(:retry,
+        max: @bad_nonce_retry,
+        interval: 0.05,
+        interval_randomness: 0.5,
+        backoff_factor: 2,
+        methods: Faraday::Connection::METHODS,
+        exceptions: [Acme::Client::Error::BadNonce])
+      end
       yield(configuration) if block_given?
       configuration.adapter Faraday.default_adapter
     end


### PR DESCRIPTION
Given that the spec states that clients should be retrying these ( https://tools.ietf.org/html/draft-ietf-acme-acme-13#section-6.4 ) it makes sense to deal with retries on the client level rather than
relying on the consumers to deal with it.

I know that there was a discussion around this here https://github.com/unixcharles/acme-client/issues/148, just seems that it's easier to have this be transparent to clients.