### PR TITLE
Add an ugly fix for a problem with the api

### DIFF
--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -38,7 +38,9 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
   private
 
   def jws_header
-    headers = { nonce: pop_nonce, url: env.url.to_s }
+    # hack to include the port which boulder expects but URI::HTTPS#to_s omits
+    url = "#{env.url.scheme}://#{env.url.hostname}:#{env.url.port}#{env.url.path}"
+    headers = { nonce: pop_nonce, url: url }
     headers[:kid] = client.kid if @mode == :kid
     headers
   end

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -38,7 +38,7 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
   private
 
   def jws_header
-    # hack to include the port which boulder expects but URI::HTTPS#to_s omits
+    # HACK to include the port which boulder expects but URI::HTTPS#to_s omits
     url = "#{env.url.scheme}://#{env.url.hostname}:#{env.url.port}#{env.url.path}"
     headers = { nonce: pop_nonce, url: url }
     headers[:kid] = client.kid if @mode == :kid


### PR DESCRIPTION
acme-client receives the endpoints to create orders and similar stuff from the let's encrypt (boulder) `/directory` endpoint. Those urls don't include the port (443).

When querying the boulder API it expects some signed headers (JWS). In those headers Boulder expects these urls to include the port. At least that's what we recently got:

```
JWS header parameter 'url' incorrect. Expected "https://acme-v02.api.letsencrypt.org:443/acme/new-order" got "https://acme-v02.api.letsencrypt.org/acme/new-order"
```

Ruby's URI::Generic#to_s, which is used in the Faraday middleware omits the port if it's the standard port for the url scheme and there is no way to add it back other than doing some ugly string concatenations.

I'm aware that this is an ugly solution. It helped us to restore our production systems. But maybe someone has a better way to fix this or knows what changed on Let's Encrypt's side and if there is a better solution than my code?

Fixes #168 