### PR TITLE
Allow Faraday 1.0

### DIFF
--- a/acme-client.gemspec
+++ b/acme-client.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 2.9'
   spec.add_development_dependency 'webmock', '~> 3.8'
 
-  spec.add_runtime_dependency 'faraday', '~> 0.17', '< 1.0.0'
+  spec.add_runtime_dependency 'faraday', '>= 0.17', '< 2.0.0'
 end


### PR DESCRIPTION
Tests are passing locally, except one (that did not pass on `master`).

The change is trivial, but you my want to bump the major version, as this will make projects using this new version incompatible with other gems not allowing `faraday < 1.0.0`.

Fixes #178