### PR TITLE
Update code to avoid Ruby 2.7.0 warnings

### DIFF
--- a/lib/acme/client/resources/account.rb
+++ b/lib/acme/client/resources/account.rb
@@ -5,7 +5,7 @@ class Acme::Client::Resources::Account
 
   def initialize(client, **arguments)
     @client = client
-    assign_attributes(arguments)
+    assign_attributes(**arguments)
   end
 
   def kid

--- a/lib/acme/client/resources/authorization.rb
+++ b/lib/acme/client/resources/authorization.rb
@@ -5,7 +5,7 @@ class Acme::Client::Resources::Authorization
 
   def initialize(client, **arguments)
     @client = client
-    assign_attributes(arguments)
+    assign_attributes(**arguments)
   end
 
   def deactivate

--- a/lib/acme/client/resources/challenges/base.rb
+++ b/lib/acme/client/resources/challenges/base.rb
@@ -5,7 +5,7 @@ class Acme::Client::Resources::Challenges::Base
 
   def initialize(client, **arguments)
     @client = client
-    assign_attributes(arguments)
+    assign_attributes(**arguments)
   end
 
   def challenge_type

--- a/lib/acme/client/resources/order.rb
+++ b/lib/acme/client/resources/order.rb
@@ -5,7 +5,7 @@ class Acme::Client::Resources::Order
 
   def initialize(client, **arguments)
     @client = client
-    assign_attributes(arguments)
+    assign_attributes(**arguments)
   end
 
   def reload

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ $LOAD_PATH.unshift File.join(__dir__, 'support')
 require 'openssl'
 
 DIRECTORY_URL = ENV['ACME_DIRECTORY_URL'] || 'https://127.0.0.1/directory'
-OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 
 require 'acme/client'
 
@@ -18,9 +17,6 @@ require 'retry_helper'
 require 'ssl_helper'
 require 'tls_helper'
 require 'profile_helper' if ENV['RUBY_PROF']
-
-# pebble use self-signed certificate
-OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 
 RSpec.configure do |c|
   c.include Asn1Helper


### PR DESCRIPTION
When running `acme-client` with Ruby 2.7.0, I see a few warnings like:
```
/Users/danielholz/.gem/ruby/2.7.0/gems/acme-client-2.0.6/lib/acme/client/resources/account.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/danielholz/.gem/ruby/2.7.0/gems/acme-client-2.0.6/lib/acme/client/resources/account.rb:43: warning: The called method `assign_attributes' is defined here
/Users/danielholz/.gem/ruby/2.7.0/gems/acme-client-2.0.6/lib/acme/client/resources/order.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/danielholz/.gem/ruby/2.7.0/gems/acme-client-2.0.6/lib/acme/client/resources/order.rb:49: warning: The called method `assign_attributes' is defined here
/Users/danielholz/.gem/ruby/2.7.0/gems/acme-client-2.0.6/lib/acme/client/resources/authorization.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/danielholz/.gem/ruby/2.7.0/gems/acme-client-2.0.6/lib/acme/client/resources/authorization.rb:65: warning: The called method `assign_attributes' is defined here
/Users/danielholz/.gem/ruby/2.7.0/gems/acme-client-2.0.6/lib/acme/client/resources/challenges/base.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/danielholz/.gem/ruby/2.7.0/gems/acme-client-2.0.6/lib/acme/client/resources/challenges/base.rb:43: warning: The called method `assign_attributes' is defined here
```

This PR updates the calls to `assign_attributes` to explicitly splat the argument.

I also removed the redefinition of `OpenSSL::SSL::VERIFY_PEER` in the spec helper, since it also printed a warning and didn't seem to affect tests.

There is one warning remaining related to the Faraday middleware; I've opened https://github.com/lostisland/faraday/pull/1153 to address that.