### PR TITLE
Fix certificate request spec

### DIFF
--- a/spec/certificate_request_spec.rb
+++ b/spec/certificate_request_spec.rb
@@ -98,7 +98,7 @@ describe Acme::Client::CertificateRequest do
   it 'assigns the public key' do
     request = Acme::Client::CertificateRequest.new(common_name: 'example.org', private_key: test_key)
 
-    expect(request.csr.public_key.to_der).to eq(public_key_to_der(test_key))
+    expect(public_key_to_pem(request.csr.public_key)).to eq(public_key_to_pem(test_key))
     expect(request.csr.verify(request.csr.public_key)).to be(true)
   end
 

--- a/spec/support/ssl_helper.rb
+++ b/spec/support/ssl_helper.rb
@@ -104,14 +104,14 @@ module SSLHelper
   # priv - An OpenSSL::PKey::EC or OpenSSL::PKey::RSA instance.
   #
   # Returns a String.
-  def public_key_to_der(priv)
+  def public_key_to_pem(priv)
     case priv
     when OpenSSL::PKey::EC
       dup = OpenSSL::PKey::EC.new(priv.to_der)
       dup.private_key = nil
-      dup.to_der
+      dup.to_pem
     when OpenSSL::PKey::RSA
-      priv.public_key.to_der
+      priv.public_key.to_pem
     else
       raise ArgumentError, 'priv must be EC or RSA'
     end

--- a/spec/support/ssl_helper.rb
+++ b/spec/support/ssl_helper.rb
@@ -104,16 +104,16 @@ module SSLHelper
   # priv - An OpenSSL::PKey::EC or OpenSSL::PKey::RSA instance.
   #
   # Returns a String.
-  def public_key_to_pem(priv)
+  def public_key_to_pem(private_key)
     case priv
     when OpenSSL::PKey::EC
-      dup = OpenSSL::PKey::EC.new(priv.to_der)
+      dup = OpenSSL::PKey::EC.new(private_key.to_der)
       dup.private_key = nil
       dup.to_pem
     when OpenSSL::PKey::RSA
-      priv.public_key.to_pem
+      private_key.public_key.to_pem
     else
-      raise ArgumentError, 'priv must be EC or RSA'
+      raise ArgumentError, 'private_key must be EC or RSA'
     end
   end
 end

--- a/spec/support/ssl_helper.rb
+++ b/spec/support/ssl_helper.rb
@@ -105,7 +105,7 @@ module SSLHelper
   #
   # Returns a String.
   def public_key_to_pem(private_key)
-    case priv
+    case private_key
     when OpenSSL::PKey::EC
       dup = OpenSSL::PKey::EC.new(private_key.to_der)
       dup.private_key = nil


### PR DESCRIPTION
`request.csr.public_key.to_der` output the full private key for some reason.

If you dig one level deeper it you can see that its properly assigned.

Also changed it to use `pem` so that test error diff are easier to read.