### PR TITLE
Fix for HTTP Link header decoding

### DIFF
--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -82,18 +82,10 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
     end
   end
 
-  LINK_MATCH = /<(.*?)>;rel="([\w-]+)"/
-
   def decode_link_headers
     return unless env.response_headers.key?('Link')
     link_header = env.response_headers['Link']
-
-    links = link_header.split(', ').map { |entry|
-      _, link, name = *entry.match(LINK_MATCH)
-      [name, link]
-    }
-
-    Hash[*links.flatten]
+    Acme::Client::Util.decode_link_headers(link_header)
   end
 
   def store_nonce

--- a/lib/acme/client/util.rb
+++ b/lib/acme/client/util.rb
@@ -3,6 +3,17 @@ module Acme::Client::Util
     Base64.urlsafe_encode64(data).sub(/[\s=]*\z/, '')
   end
 
+  LINK_MATCH = /<(.*?)>\s?;\s?rel="([\w-]+)"/
+
+  # See RFC 8288 - https://tools.ietf.org/html/rfc8288#section-3
+  def decode_link_headers(link_header)
+    link_header.split(',').each_with_object({}) { |entry, hash|
+      _, link, name = *entry.match(LINK_MATCH)
+      hash[name] ||= []
+      hash[name].push(link)
+    }
+  end
+
   # Sets public key on CSR or cert.
   #
   # obj  - An OpenSSL::X509::Certificate or OpenSSL::X509::Request instance.

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Acme::Client::JWK do
+  context '#decode_link_headers' do
+    let(:example) do
+      '<uri1>; rel="up", <uri2>; rel="alt", <uri3>; rel="alt"'
+    end
+
+    it 'extract link value and in a hash with rel as they key' do
+      links = Acme::Client::Util.decode_link_headers(example)
+      expect(links).to be_a(Hash)
+      expect(links['up']).to eq(['uri1'])
+      expect(links['alt'].sort).to eq(%w(uri2 uri3).sort)
+    end
+  end
+end


### PR DESCRIPTION
* Move to Util and add spec
* Allow space between `;` and `rel=`, following https://tools.ietf.org/html/rfc8288#section-3-5
* Change hash value to an Array of values to allow multiple entries at the same rel

fix https://github.com/unixcharles/acme-client/pull/187/files#diff-e843384610a1a0cb8c21582bbed52188R323-R329