### PR TITLE
Update README to note the new Let's Encrypt transition date

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ order.certificate # => PEM-formatted certificate
 
 ### Ordering an alternative certificate
 
-Let's Encrypt is transitioning to use a new, self-signed intermediate certificate. Starting January 11, 2021 new certificates will be signed by their own intermediate. To ease the transition on clients Let's Encrypt will continue signing an alternative version of the certificate using the old, cross-signed intermediate until September 29, 2021. In order to utilize an alternative certificate the `Order#certificate` method accepts a `force_chain` keyword argument.
+Let's Encrypt is [transitioning](https://letsencrypt.org/2019/04/15/transitioning-to-isrg-root.html) to use a new, self-signed intermediate certificate. Starting January 11, 2021 new certificates will be signed by their own intermediate. To ease the transition on clients Let's Encrypt will continue signing an alternative version of the certificate using the old, cross-signed intermediate until September 29, 2021. In order to utilize an alternative certificate the `Order#certificate` method accepts a `force_chain` keyword argument.
 For example, to download the cross-signed certificate after January 11, 2021, call `Order#certificate` as follows:
  
 ```ruby

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ order.certificate # => PEM-formatted certificate
 
 ### Ordering an alternative certificate
 
-Let's Encrypt is transitioning to use a new, self-signed intermediate certificate. Starting September 29, 2020 new certificates will be signed by their own intermediate. To ease the transition on clients Let's Encrypt will continue signing an alternative version of the certificate using the old, cross-signed intermediate until September 29, 2021. In order to utilize an alternative certificate the `Order#certificate` method accepts a `force_chain` keyword argument. 
-For example, to download the cross-signed certificate after September 29, 2020, call `Order#certificate` as follows:
+Let's Encrypt is transitioning to use a new, self-signed intermediate certificate. Starting January 11, 2021 new certificates will be signed by their own intermediate. To ease the transition on clients Let's Encrypt will continue signing an alternative version of the certificate using the old, cross-signed intermediate until September 29, 2021. In order to utilize an alternative certificate the `Order#certificate` method accepts a `force_chain` keyword argument.
+For example, to download the cross-signed certificate after January 11, 2021, call `Order#certificate` as follows:
  
 ```ruby
 begin


### PR DESCRIPTION
On Sept 17, 2020 Let's Encrypt [posted an update](https://letsencrypt.org/2019/04/15/transitioning-to-isrg-root.html) that they are deferring the transition to the new root certificate.

This patch updates the README to mention the new transition date (Jan 11, 2021), and adds a link to the Let's Encrypt post about the transition.