### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ order.certificate # => PEM-formatted certificate
 
 ### Ordering an alternative certificate
 
-Let's Encrypt is [transitioning](https://letsencrypt.org/2019/04/15/transitioning-to-isrg-root.html) to use a new, self-signed intermediate certificate. Starting January 11, 2021 new certificates will be signed by their own intermediate. To ease the transition on clients Let's Encrypt will continue signing an alternative version of the certificate using the old, cross-signed intermediate until September 29, 2021. In order to utilize an alternative certificate the `Order#certificate` method accepts a `force_chain` keyword argument, which takes the issuer name of the intermediate certificate.
+Let's Encrypt is [transitioning](https://letsencrypt.org/2019/04/15/transitioning-to-isrg-root.html) to use a new intermediate certificate. Starting January 11, 2021 new certificates will be signed by their own intermediate. To ease the transition on clients Let's Encrypt will continue signing an alternative version of the certificate using the old, cross-signed intermediate until September 29, 2021. In order to utilize an alternative certificate the `Order#certificate` method accepts a `force_chain` keyword argument, which takes the issuer name of the intermediate certificate.
 For example, to download the cross-signed certificate after January 11, 2021, call `Order#certificate` as follows:
 
 ```ruby


### PR DESCRIPTION
"self-signed" is typically used in a different way - while we are using our own intermediate cert (like you mention in the next sentence), it might confuse users to also describe it at self-signed.