### PR TITLE
Add padding to bring it up to the required byte size for EC keys

### DIFF
--- a/lib/acme/client/jwk/ecdsa.rb
+++ b/lib/acme/client/jwk/ecdsa.rb
@@ -73,8 +73,10 @@ class Acme::Client::JWK::ECDSA < Acme::Client::JWK::Base
     # BigNumbers
     bns = ints.map(&:value)
 
+    byte_size = (@private_key.group.degree + 7) / 8
+
     # Binary R/S values
-    r, s = bns.map { |bn| [bn.to_s(16)].pack('H*') }
+    r, s = bns.map { |bn| bn.to_s(2).rjust(byte_size, "\x00") }
 
     # JWS wants raw R/S concatenated.
     [r, s].join


### PR DESCRIPTION
In the [RFC](https://tools.ietf.org/html/rfc7518#section-3.4) for JWA it says that R and S need to be padded to 32 bits (based on the key size).

I believe this is causing errors with lets encrypt of the form 
> Acme::Client::Error::Malformed : JWS verification error

copied from: https://github.com/nov/json-jwt/blob/d97f1be725dcb601fb8ca44b1d933614986c9c27/lib/json/jws.rb#L172