### PR TITLE
Check alternate chains prior to default chain when providing force_chain

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -156,16 +156,16 @@ class Acme::Client
 
     return pem if force_chain.nil?
 
-    return pem if ChainIdentifier.new(pem).match_name?(force_chain)
-
     alternative_urls = Array(response.headers.dig('link', 'alternate'))
     alternative_urls.each do |alternate_url|
       response = download(alternate_url, format: :pem)
-      pem = response.body
-      if ChainIdentifier.new(pem).match_name?(force_chain)
-        return pem
+      alternate_pem = response.body
+      if ChainIdentifier.new(alternate_pem).match_name?(force_chain)
+        return alternate_pem
       end
     end
+
+    return pem if ChainIdentifier.new(pem).match_name?(force_chain)
 
     raise Acme::Client::Error::ForcedChainNotFound, "Could not find any matching chain for `#{force_chain}`"
   end


### PR DESCRIPTION
Let's Encrypt changed their default and alternate chains as of May 4th.  
https://community.letsencrypt.org/t/production-chain-changes/150739

Issue is that we are unable to retrieve the new alternate chain as the force_chain attribute (in this case 'ISRG Root X1') is included in the default chain as well as the alternate. 
This change allows for retrieving the alternate chain when both default and alternate contains the provided issuer. If one wants the default chain, then they can simply not provide any force_chain attribute. 