### PR TITLE
Fix compatibility with both Ruby 3.0 and Faraday 0.17.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+if faraday_version = ENV['FARADAY_VERSION']
+  gem 'faraday', faraday_version
+end
+
 group :development, :test do
   gem 'pry'
   gem 'rubocop', '~> 0.49.0'

--- a/acme-client.gemspec
+++ b/acme-client.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'vcr', '~> 2.9'
   spec.add_development_dependency 'webmock', '~> 3.8'
+  spec.add_development_dependency 'webrick'
 
   spec.add_runtime_dependency 'faraday', '>= 0.17', '< 2.0.0'
 end

--- a/lib/acme/client/faraday_middleware.rb
+++ b/lib/acme/client/faraday_middleware.rb
@@ -5,10 +5,10 @@ class Acme::Client::FaradayMiddleware < Faraday::Middleware
 
   CONTENT_TYPE = 'application/jose+json'
 
-  def initialize(app, client:, mode:)
+  def initialize(app, options)
     super(app)
-    @client = client
-    @mode = mode
+    @client = options.fetch(:client)
+    @mode = options.fetch(:mode)
   end
 
   def call(env)

--- a/lib/acme/client/resources/directory.rb
+++ b/lib/acme/client/resources/directory.rb
@@ -70,6 +70,8 @@ class Acme::Client::Resources::Directory
   def fetch_directory
     connection = Faraday.new(url: @directory, **@connection_options) do |configuration|
       configuration.use Acme::Client::FaradayMiddleware, client: nil, mode: nil
+
+      configuration.adapter Faraday.default_adapter
     end
     connection.headers[:user_agent] = Acme::Client::USER_AGENT
     response = connection.get(@url)


### PR DESCRIPTION
The gemspec claims compatibility with Faraday 0.17.x, but previously the test suite was not passing as the Faraday client built in `fetch_directory` did not have an adapter configured.

Additionally the test suite did not run under Ruby 3.0 (with any version of Faraday) because of a missing dependency on webrick.

Finally, when Faraday 0.17.x and Ruby 3.0 were used in combination `FaradayMiddleware` would error on initialization since Faraday 0.17 always passes an options hash, which are no longer compatible with kwargs.. I think it's safest to assume this as an options hash even in Faraday 1+ since that is relying on the `ruby2_keywords` hack, and that should keep compatibility with all versions.