### PR TITLE
Support Faraday v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['2.6', '2.7', '3.0', truffleruby-head]
-        faraday-version: ['~> 0.17.3', '~> 1.7']
+        faraday-version: ['~> 1.7', '~> 2.0']
     env:
       FARADAY_VERSION: ${{ matrix.faraday-version }}
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,4 @@ group :development, :test do
   gem 'pry'
   gem 'rubocop', '~> 0.49.0'
   gem 'ruby-prof', require: false
-
-  if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('2.2.2')
-    gem 'activesupport', '~> 4.2.6'
-  end
 end

--- a/acme-client.gemspec
+++ b/acme-client.gemspec
@@ -14,18 +14,15 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17.3'
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2')
-    spec.add_development_dependency 'rake', '>= 12.0'
-  else
-    spec.add_development_dependency 'rake', '~> 13.0'
-  end
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'vcr', '~> 2.9'
   spec.add_development_dependency 'webmock', '~> 3.8'
   spec.add_development_dependency 'webrick'
 
-  spec.add_runtime_dependency 'faraday', '>= 0.17', '< 2.0.0'
+  spec.add_runtime_dependency 'faraday', '>= 1.0', '< 3.0.0'
+  spec.add_runtime_dependency 'faraday-retry', '~> 1.0'
 end

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'faraday'
+require 'faraday/retry'
 require 'json'
 require 'openssl'
 require 'digest'


### PR DESCRIPTION
This PR adds support for Faraday 2.x.

Tests still pass back to Faraday 1.0, but not on 0.17, so I bumped the minimum Faraday version to 1.0.

Since Faraday 1.0 requires Ruby 2.3+, I also bumped acme-client's minimum Ruby to the same. I don't have a running Ruby that old, but did successfully test on Ruby 2.5.