### PR TITLE
Change generated CSR version to 0

### DIFF
--- a/lib/acme/client/certificate_request.rb
+++ b/lib/acme/client/certificate_request.rb
@@ -89,7 +89,7 @@ class Acme::Client::CertificateRequest
       end
       csr.public_key = @private_key
       csr.subject = generate_subject
-      csr.version = 2
+      csr.version = 0
       add_extension(csr)
       csr.sign @private_key, @digest
     end


### PR DESCRIPTION
CSRs are PKCS#10 documents, and the standard does not define versions above 0.

Reference: https://github.com/certbot/certbot/pull/9334