### PR TITLE
don't include dotfiles in gem

### DIFF
--- a/acme-client.gemspec
+++ b/acme-client.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/unixcharles/acme-client'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) || f.start_with?('.') }
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.3.0'


### PR DESCRIPTION
Fixes #227.

Here's the proof that it works:

```
dan@nexterday acme-client % git st
On branch exclude-rubocop-yml-from-gem
nothing to commit, working tree clean
dan@nexterday acme-client % gem build
WARNING:  open-ended dependency on bundler (>= 1.17.3, development) is not recommended
  if bundler is semantically versioned, use:
    add_development_dependency 'bundler', '~> 1.17', '>= 1.17.3'
WARNING:  open-ended dependency on webrick (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: acme-client
  Version: 2.0.14
  File: acme-client-2.0.14.gem
dan@nexterday acme-client % mkdir gem_output && tar -xf acme-client-2.0.14.gem -C gem_output
dan@nexterday acme-client % cd gem_output
dan@nexterday gem_output % tar -xf data.tar.gz
dan@nexterday gem_output % ls -a .*
zsh: no matches found: .*
```