### PR TITLE
get_nonce: Respect connection_options

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -223,7 +223,7 @@ class Acme::Client
   end
 
   def get_nonce
-    http_client = Acme::Client::HTTPClient.new_connection(url: endpoint_for(:new_nonce))
+    http_client = Acme::Client::HTTPClient.new_connection(url: endpoint_for(:new_nonce), options: @connection_options)
     response = http_client.head(nil, nil)
     nonces << response.headers['replay-nonce']
     true


### PR DESCRIPTION
`Client#get_nonce` doesn't pass `@connection_options` when generating its own Faraday instance. If connection_options contain a SSL configuration that is required to connect to the endpoint, then Client fails to connect (as nonce is mandatory for ACME requests).

 For instance, I have a [integration test](https://github.com/sorah/acmesmith/pull/59) using https://github.com/letsencrypt/pebble and it comes with self-issued server certificate that has to be trusted to connect.