### PR TITLE
Refactor http operation out of Directory

### DIFF
--- a/spec/cassettes/directory_endpoint_for.yml
+++ b/spec/cassettes/directory_endpoint_for.yml
@@ -8,7 +8,9 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Acme::Client v2.0.4 (https://github.com/unixcharles/acme-client)
+      - Acme::Client v2.0.15 (https://github.com/unixcharles/acme-client)
+      Content-Type:
+      - application/jose+json
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -23,15 +25,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 10 Oct 2019 03:08:14 GMT
+      - Tue, 16 Jan 2024 18:10:15 GMT
       Content-Length:
-      - '386'
+      - '396'
     body:
       encoding: UTF-8
       string: |-
         {
            "keyChange": "<DIRECTORY_BASE_URL>/rollover-account-key",
            "meta": {
+              "externalAccountRequired": false,
               "termsOfService": "data:text/plain,Do%20what%20thou%20wilt"
            },
            "newAccount": "<DIRECTORY_BASE_URL>/sign-me-up",
@@ -39,6 +42,89 @@ http_interactions:
            "newOrder": "<DIRECTORY_BASE_URL>/order-plz",
            "revokeCert": "<DIRECTORY_BASE_URL>/revoke-cert"
         }
-    http_version: 
-  recorded_at: Thu, 10 Oct 2019 03:08:14 GMT
+    http_version:
+  recorded_at: Tue, 16 Jan 2024 18:10:15 GMT
+- request:
+    method: head
+    uri: "<DIRECTORY_BASE_URL>/nonce-plz"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Acme::Client v2.0.15 (https://github.com/unixcharles/acme-client)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - public, max-age=0, no-cache
+      Link:
+      - <<DIRECTORY_URL>>;rel="index"
+      Replay-Nonce:
+      - DXS4nYJl18Pid0N5tjRffw
+      Date:
+      - Tue, 16 Jan 2024 18:10:15 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version:
+  recorded_at: Tue, 16 Jan 2024 18:10:15 GMT
+- request:
+    method: post
+    uri: "<DIRECTORY_BASE_URL>/sign-me-up"
+    body:
+      encoding: UTF-8
+      string: '{"protected":"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCIsIm5vbmNlIjoiRFhTNG5ZSmwxOFBpZDBONXRqUmZmdyIsInVybCI6Imh0dHBzOi8vMC4wLjAuMDoxNDAwMC9zaWduLW1lLXVwIiwiandrIjp7ImNydiI6IlAtMzg0Iiwia3R5IjoiRUMiLCJ4IjoiMm5NOHg0aVR4UElLcUZqR01jX3RiY2QxOW1QT1pydld1S3ZpYlU3MGsxWlZwaU9LQ2p2c3N3Yl9OT0JNX29lYiIsInkiOiJHaHFaN3d2dXhRb05VRThJclBkVF9qVkVOQmJqRThjWVBjYnIwMkdrTk0tSHNhanNJWGRrNTYyNXZsNVpVdkhNIn19","payload":"eyJjb250YWN0IjpbIm1haWx0bzppbmZvQGV4YW1wbGUuY29tIl0sInRlcm1zT2ZTZXJ2aWNlQWdyZWVkIjp0cnVlfQ","signature":"_Ct6M9duFtXOxtZDWLwrxcVv49z3l2JJCDFGuQQ1HyUvbnBfoVPNuLssJEQ3bXz_Dh-F-W32DTPaOoPAvlIwWOV-WuHZEYuw1DeR8GwGS68cC-xbU2Fbs1c5Fu5bHhU-"}'
+    headers:
+      User-Agent:
+      - Acme::Client v2.0.15 (https://github.com/unixcharles/acme-client)
+      Content-Type:
+      - application/jose+json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - public, max-age=0, no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Link:
+      - <<DIRECTORY_URL>>;rel="index"
+      Location:
+      - "<DIRECTORY_BASE_URL>/my-account/3011c37ad722d86"
+      Replay-Nonce:
+      - "-0Wz_OugGSEpZJRBPs8X2g"
+      Date:
+      - Tue, 16 Jan 2024 18:10:15 GMT
+      Content-Length:
+      - '360'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+           "status": "valid",
+           "contact": [
+              "mailto:info@example.com"
+           ],
+           "orders": "<DIRECTORY_BASE_URL>/list-orderz/3011c37ad722d86",
+           "key": {
+              "kty": "EC",
+              "crv": "P-384",
+              "x": "2nM8x4iTxPIKqFjGMc_tbcd19mPOZrvWuKvibU70k1ZVpiOKCjvsswb_NOBM_oeb",
+              "y": "GhqZ7wvuxQoNUE8IrPdT_jVENBbjE8cYPcbr02GkNM-HsajsIXdk5625vl5ZUvHM"
+           }
+        }
+    http_version:
+  recorded_at: Tue, 16 Jan 2024 18:10:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/directory_meta.yml
+++ b/spec/cassettes/directory_meta.yml
@@ -8,7 +8,9 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Acme::Client v2.0.4 (https://github.com/unixcharles/acme-client)
+      - Acme::Client v2.0.15 (https://github.com/unixcharles/acme-client)
+      Content-Type:
+      - application/jose+json
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -23,15 +25,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 10 Oct 2019 03:08:14 GMT
+      - Tue, 16 Jan 2024 18:10:51 GMT
       Content-Length:
-      - '386'
+      - '396'
     body:
       encoding: UTF-8
       string: |-
         {
            "keyChange": "<DIRECTORY_BASE_URL>/rollover-account-key",
            "meta": {
+              "externalAccountRequired": false,
               "termsOfService": "data:text/plain,Do%20what%20thou%20wilt"
            },
            "newAccount": "<DIRECTORY_BASE_URL>/sign-me-up",
@@ -39,6 +42,89 @@ http_interactions:
            "newOrder": "<DIRECTORY_BASE_URL>/order-plz",
            "revokeCert": "<DIRECTORY_BASE_URL>/revoke-cert"
         }
-    http_version: 
-  recorded_at: Thu, 10 Oct 2019 03:08:14 GMT
+    http_version:
+  recorded_at: Tue, 16 Jan 2024 18:10:51 GMT
+- request:
+    method: head
+    uri: "<DIRECTORY_BASE_URL>/nonce-plz"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Acme::Client v2.0.15 (https://github.com/unixcharles/acme-client)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - public, max-age=0, no-cache
+      Link:
+      - <<DIRECTORY_URL>>;rel="index"
+      Replay-Nonce:
+      - Tuty2P8DM9lQfIoWYI_xIA
+      Date:
+      - Tue, 16 Jan 2024 18:10:51 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version:
+  recorded_at: Tue, 16 Jan 2024 18:10:51 GMT
+- request:
+    method: post
+    uri: "<DIRECTORY_BASE_URL>/sign-me-up"
+    body:
+      encoding: UTF-8
+      string: '{"protected":"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCIsIm5vbmNlIjoiVHV0eTJQOERNOWxRZklvV1lJX3hJQSIsInVybCI6Imh0dHBzOi8vMC4wLjAuMDoxNDAwMC9zaWduLW1lLXVwIiwiandrIjp7ImNydiI6IlAtMzg0Iiwia3R5IjoiRUMiLCJ4IjoiNkZ2SzNfZ3Ywei1mZ250b0VRQWFmUGxpZHVxUXd0QlpsMGdqTDRzc2ltdm5Cd0M4aWxYVlBiLWNNTlBxaFEwaSIsInkiOiJla2lEa29YTVlXTmhvSWwydTRUcEg2U3oyOXlXMkZpMm1qenhBYVRzTGpQczVIMnhQWW1GYlBRRmF1N3EzejVQIn19","payload":"eyJjb250YWN0IjpbIm1haWx0bzppbmZvQGV4YW1wbGUuY29tIl0sInRlcm1zT2ZTZXJ2aWNlQWdyZWVkIjp0cnVlfQ","signature":"TD8n-T2m1qE1mo9uZTl7AJax1D1LclTBixqXZmeyQi7xXQjSeGWdtBPpjvE6d0kCSpQNGv6GcBJgYHS-QoK-z-4YQnCDggCMetyn2d9MFeYuqiEhM9XrULchX58ZmiFe"}'
+    headers:
+      User-Agent:
+      - Acme::Client v2.0.15 (https://github.com/unixcharles/acme-client)
+      Content-Type:
+      - application/jose+json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - public, max-age=0, no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Link:
+      - <<DIRECTORY_URL>>;rel="index"
+      Location:
+      - "<DIRECTORY_BASE_URL>/my-account/4530875a31aa979c"
+      Replay-Nonce:
+      - wgZvnNCEXH7AO9RaizC3Tw
+      Date:
+      - Tue, 16 Jan 2024 18:10:51 GMT
+      Content-Length:
+      - '361'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+           "status": "valid",
+           "contact": [
+              "mailto:info@example.com"
+           ],
+           "orders": "<DIRECTORY_BASE_URL>/list-orderz/4530875a31aa979c",
+           "key": {
+              "kty": "EC",
+              "crv": "P-384",
+              "x": "6FvK3_gv0z-fgntoEQAafPliduqQwtBZl0gjL4ssimvnBwC8ilXVPb-cMNPqhQ0i",
+              "y": "ekiDkoXMYWNhoIl2u4TpH6Sz29yW2Fi2mjzxAaTsLjPs5H2xPYmFbPQFau7q3z5P"
+           }
+        }
+    http_version:
+  recorded_at: Tue, 16 Jan 2024 18:10:51 GMT
 recorded_with: VCR 2.9.3

--- a/spec/directory_spec.rb
+++ b/spec/directory_spec.rb
@@ -1,7 +1,14 @@
 require 'spec_helper'
 
 describe Acme::Client::Resources::Directory do
-  let(:directory) { Acme::Client::Resources::Directory.new(DIRECTORY_URL, {}) }
+  let(:private_key) { generate_private_key }
+  let(:client) do
+    client = Acme::Client.new(private_key: private_key, directory: DIRECTORY_URL)
+    client.new_account(contact: 'mailto:info@example.com', terms_of_service_agreed: true)
+    client
+  end
+
+  let(:directory) { client.directory }
 
   context 'endpoint_for', vcr: { cassette_name: 'directory_endpoint_for' } do
     it { expect(directory.endpoint_for(:new_nonce)).to be_a_kind_of(URI) }
@@ -22,6 +29,6 @@ describe Acme::Client::Resources::Directory do
   context 'meta', vcr: { cassette_name: 'directory_meta' } do
     it { expect(directory.meta).to be_a(Hash) }
     it { expect(directory.terms_of_service).to be_a(String) }
-    it { expect(directory.external_account_required).to be_nil }
+    it { expect(directory.external_account_required).to be false }
   end
 end


### PR DESCRIPTION
- More consistent with other resources
- Fix quirks with using an http client that doesn't have an acme-client
- Fix crash when using Google ACME endpoint (because it return nonce on directory which the client doesn't know how to handle)
- 
fix #232 