### PR TITLE
Set authorization token to `nil` if there is no token in the challenge

### DIFF
--- a/lib/acme/client/resources/authorization.rb
+++ b/lib/acme/client/resources/authorization.rb
@@ -56,7 +56,7 @@ class Acme::Client::Resources::Authorization
       type: attributes.fetch('type'),
       status: attributes.fetch('status'),
       url: attributes.fetch('url'),
-      token: attributes.fetch('token'),
+      token: attributes.fetch('token', nil),
       error: attributes['error']
     }
     Acme::Client::Resources::Challenges.new(@client, **arguments)


### PR DESCRIPTION
Some CA providers are not setting the authorization token when the domain was pre-validated for an organization (using other non-ACME domains validation method). 

This is making the client crash as it cannot fetch the token (the DNS TXT record is not needed):

```
key not found: "token",
Backtrace: ["/app/vendor/gems/ruby/3.2.0/gems/acme-client-2.0.16/lib/acme/client/resources/authorization.rb:59:in `fetch'",
"/app/vendor/gems/ruby/3.2.0/gems/acme-client-2.0.16/lib/acme/client/resources/authorization.rb:59:in `initialize_challenge'",
"/app/vendor/gems/ruby/3.2.0/gems/acme-client-2.0.16/lib/acme/client/resources/authorization.rb:23:in `block in challenges'",
"/app/vendor/gems/ruby/3.2.0/gems/acme-client-2.0.16/lib/acme/client/resources/authorization.rb:22:in `map'",
"/app/vendor/gems/ruby/3.2.0/gems/acme-client-2.0.16/lib/acme/client/resources/authorization.rb:22:in `challenges'", 
...
```

This is setting up the token to `nil` if no token was provided by the CA.

I didn't bump the gem version, let me know if I should