### PR TITLE
fix the encoding of ECDSA public keys with leading 00's

### DIFF
--- a/lib/acme/client/jwk/ecdsa.rb
+++ b/lib/acme/client/jwk/ecdsa.rb
@@ -50,8 +50,8 @@ class Acme::Client::JWK::ECDSA < Acme::Client::JWK::Base
     {
       crv: @curve_params[:jwa_crv],
       kty: 'EC',
-      x: Acme::Client::Util.urlsafe_base64(coordinates[:x].to_s(2)),
-      y: Acme::Client::Util.urlsafe_base64(coordinates[:y].to_s(2))
+      x: Acme::Client::Util.urlsafe_base64(coordinates[:x]),
+      y: Acme::Client::Util.urlsafe_base64(coordinates[:y])
     }
   end
 
@@ -92,8 +92,8 @@ class Acme::Client::JWK::ECDSA < Acme::Client::JWK::Base
       hex_y = hex[2 + data_len / 2, data_len / 2]
 
       {
-        x: OpenSSL::BN.new([hex_x].pack('H*'), 2),
-        y: OpenSSL::BN.new([hex_y].pack('H*'), 2)
+        x: [hex_x].pack('H*'),
+        y: [hex_y].pack('H*')
       }
     end
   end


### PR DESCRIPTION
The public portion of an ECDSA public key has an 'x' and 'y' component. For a new account request that uses EAB token, this public key is added to the protected section of the JWS. When encoding the key, it's important to preserve all of the bytes in the different parts, even if they are zero bytes.

The previous encoding would dump the key to hex and split the x and y component from those, then encode them into an OpenSSL bignum, then dump that bignum to bytes and urlsafe-base64 encode that. But OpenSSL's bignum does not track the number of input bytes, only the most compact representation of the number. This means that leading zero bytes are dropped when re-encoded into a byte array from the bignum.

Pushing the 'x' and 'y' component through OpenSSL::BN is unecessary and causes issues for ECDSA keys that are randomly generated with leading zeros. This can be demonstrated with the following code:

``` irb
irb> OpenSSL::BN.new("00FF", 16).to_s(2)
=> "\xFF"
```

The test generates a key with a leading zero for the encoded 'x' component, then checks to make sure the JWS contains the corresponding 0x00 bytes in the encoding for 'x'.