### PR TITLE
add base64 dependency for future-proofing

### DIFF
--- a/acme-client.gemspec
+++ b/acme-client.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.8'
   spec.add_development_dependency 'webrick', '~> 1.7'
 
+  spec.add_runtime_dependency 'base64', '~> 0.2.0'
   spec.add_runtime_dependency 'faraday', '>= 1.0', '< 3.0.0'
   spec.add_runtime_dependency 'faraday-retry', '>= 1.0', '< 3.0.0'
 end


### PR DESCRIPTION
When working in anchordotdev/puma-acme we started getting a failure against head ruby, because it no longer has base64 in stdlib, and instead you have to explicitly require it. You can see the error here:

https://github.com/anchordotdev/puma-acme/actions/runs/10150742999/job/28068516562

We added it ourselves to immediately address the issue, but wanted to pass the fix upstream to you as well. I don't believe it should change any current behavior, and should help future proof things so you won't need to address this when 3.4+ appear.

Just let me know if you have any questions or I can help further to land this. Thanks!