### PR TITLE
CSR version should be set to zero

### DIFF
--- a/lib/acme/client/certificate_request.rb
+++ b/lib/acme/client/certificate_request.rb
@@ -89,7 +89,7 @@ class Acme::Client::CertificateRequest
       end
       csr.public_key = @private_key
       csr.subject = generate_subject
-      csr.version = 2
+      csr.version = 0
       add_extension(csr)
       csr.sign @private_key, @digest
     end

--- a/spec/certificate_request_spec.rb
+++ b/spec/certificate_request_spec.rb
@@ -145,4 +145,10 @@ describe Acme::Client::CertificateRequest do
 
     expect(request.csr.verify(ec_key)).to be(true)
   end
+
+  it 'generate the request with version zero' do
+    request = Acme::Client::CertificateRequest.new(common_name: 'example.org', private_key: test_key)
+
+    expect(request.csr.version).to be_zero
+  end
 end


### PR DESCRIPTION
As per specification https://www.rfc-editor.org/rfc/rfc2986

```
version is the version number, for compatibility with future
revisions of this document.  It shall be 0 for this version of
the standard.
```

Fix #242 