### PR TITLE
Add Ruby 3.3 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', truffleruby]
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', truffleruby]
         faraday-version: ['~> 1.10', '~> 2.9']
     env:
       FARADAY_VERSION: ${{ matrix.faraday-version }}


### PR DESCRIPTION
With this pull request we're adding support for `Ruby 3.3`.