### PR TITLE
Add validated to challenges

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -310,7 +310,7 @@ class Acme::Client
   end
 
   def attributes_from_challenge_response(response)
-    extract_attributes(response.body, :status, :url, :token, :type, :error)
+    extract_attributes(response.body, :status, :url, :token, :type, :error, :validated)
   end
 
   def extract_attributes(input, *attributes)

--- a/lib/acme/client/resources/challenges/base.rb
+++ b/lib/acme/client/resources/challenges/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Acme::Client::Resources::Challenges::Base
-  attr_reader :status, :url, :token, :error
+  attr_reader :status, :url, :token, :error, :validated
 
   def initialize(client, **arguments)
     @client = client
@@ -29,7 +29,7 @@ class Acme::Client::Resources::Challenges::Base
   end
 
   def to_h
-    { status: status, url: url, token: token, error: error }
+    { status: status, url: url, token: token, error: error, validated: validated }
   end
 
   private
@@ -40,10 +40,11 @@ class Acme::Client::Resources::Challenges::Base
     ).to_h
   end
 
-  def assign_attributes(status:, url:, token:, error: nil)
+  def assign_attributes(status:, url:, token:, error: nil, validated: nil)
     @status = status
     @url = url
     @token = token
     @error = error
+    @validated = validated
   end
 end

--- a/spec/challenge_spec.rb
+++ b/spec/challenge_spec.rb
@@ -18,6 +18,7 @@ describe Acme::Client::Resources::Challenges do
     it 'reload reload the challenge' do
       expect { http01.reload }.not_to raise_error
       expect(http01.url).not_to be_nil
+      expect(http01.validated).to be_nil
     end
   end
 
@@ -43,6 +44,7 @@ describe Acme::Client::Resources::Challenges do
         }.to_not raise_error
 
         expect(http01.status).to eq('valid')
+        expect(http01.validated).not_to be_nil
       end
     end
 
@@ -60,6 +62,7 @@ describe Acme::Client::Resources::Challenges do
 
         expect(http01.status).to eq('invalid')
         expect(http01.error).to_not be_empty
+        expect(http01.validated).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
[RFC 8555, Section 8](https://datatracker.ietf.org/doc/html/rfc8555#section-8) includes "validated" as an optional field on Challenge objects. This PR adds a reader for the validated value to the `Base` challenge object.