### PR TITLE
Loosen base64 dependency constraint

### DIFF
--- a/acme-client.gemspec
+++ b/acme-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.8'
   spec.add_development_dependency 'webrick', '~> 1.7'
 
-  spec.add_runtime_dependency 'base64', '~> 0.2.0'
+  spec.add_runtime_dependency 'base64', '~> 0.2'
   spec.add_runtime_dependency 'faraday', '>= 1.0', '< 3.0.0'
   spec.add_runtime_dependency 'faraday-retry', '>= 1.0', '< 3.0.0'
 end


### PR DESCRIPTION
base64 v0.3.0 was released last month, and doesn't appear to have any code changes that would affect this library. Loosening the constraint here will allow users of this library to upgrade to the latest base64.

https://github.com/ruby/base64/releases/tag/v0.3.0