### PR TITLE
make Order url an optional argument

### DIFF
--- a/lib/acme/client/error.rb
+++ b/lib/acme/client/error.rb
@@ -9,6 +9,7 @@ class Acme::Client::Error < StandardError
   class CertificateNotReady < ClientError; end
   class ForcedChainNotFound < ClientError; end
   class OrderNotReady < ClientError; end
+  class OrderNotReloadable < ClientError; end
 
   class ServerError < Acme::Client::Error; end
   class AlreadyRevoked < ServerError; end

--- a/lib/acme/client/resources/order.rb
+++ b/lib/acme/client/resources/order.rb
@@ -46,7 +46,7 @@ class Acme::Client::Resources::Order
 
   private
 
-  def assign_attributes(url:, status:, expires:, finalize_url:, authorization_urls:, identifiers:, certificate_url: nil)
+  def assign_attributes(url: nil, status:, expires:, finalize_url:, authorization_urls:, identifiers:, certificate_url: nil)
     @url = url
     @status = status
     @expires = expires

--- a/lib/acme/client/resources/order.rb
+++ b/lib/acme/client/resources/order.rb
@@ -9,6 +9,10 @@ class Acme::Client::Resources::Order
   end
 
   def reload
+    if url.nil?
+      raise Acme::Client::Error::OrderNotReloadable, 'Finalized orders are not reloadable for this CA'
+    end
+
     assign_attributes(**@client.order(url: url).to_h)
     true
   end


### PR DESCRIPTION
RFC8555 doesn't require the `Location` header to be present on the order resource's "finialize" URL responses. The ACME implementation at buypass.com (`https://api.buypass.com/acme/directory`) does not set the Location header for these responses, which was breaking the order object creation after a successful response.