### PR TITLE
Profiles Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,22 @@ new_private_key = OpenSSL::PKey::RSA.new(4096)
 client.account_key_change(new_private_key: new_private_key)
 ```
 
+### Profile Extension
+
+Provide a CA profile when creating a new order:
+
+```ruby
+order = client.new_order(identifiers: ['example.com'], profile: 'shortlived')
+```
+
+ACME servers may list supported profiles in the directory endpoint:
+
+```ruby
+client.profiles => {"classic": "https://example.com/docs/classic", "shortlived": "https://example.com/docs/shortlived"}
+```
+
+See the [RFC draft of certificate profiles](https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/) for more info.
+
 ## Requirements
 
 Ruby >= 3.0

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -135,11 +135,12 @@ class Acme::Client
     @kid ||= account.kid
   end
 
-  def new_order(identifiers:, not_before: nil, not_after: nil)
+  def new_order(identifiers:, not_before: nil, not_after: nil, profile: nil)
     payload = {}
     payload['identifiers'] = prepare_order_identifiers(identifiers)
     payload['notBefore'] = not_before if not_before
     payload['notAfter'] = not_after if not_after
+    payload['profile'] = profile if profile
 
     response = post(endpoint_for(:new_order), payload: payload)
     arguments = attributes_from_order_response(response)
@@ -253,6 +254,10 @@ class Acme::Client
     directory.external_account_required
   end
 
+  def profiles
+    directory.profiles
+  end
+
   private
 
   def load_directory
@@ -299,7 +304,8 @@ class Acme::Client
       [:finalize_url, 'finalize'],
       [:authorization_urls, 'authorizations'],
       [:certificate_url, 'certificate'],
-      :identifiers
+      :identifiers,
+      :profile
     )
 
     attributes[:url] = response.headers[:location] if response.headers[:location]

--- a/lib/acme/client/resources/directory.rb
+++ b/lib/acme/client/resources/directory.rb
@@ -14,7 +14,8 @@ class Acme::Client::Resources::Directory
     terms_of_service: 'termsOfService',
     website: 'website',
     caa_identities: 'caaIdentities',
-    external_account_required: 'externalAccountRequired'
+    external_account_required: 'externalAccountRequired',
+    profiles: 'profiles'
   }
 
   def initialize(client, **arguments)
@@ -43,6 +44,10 @@ class Acme::Client::Resources::Directory
 
   def external_account_required
     meta[DIRECTORY_META[:external_account_required]]
+  end
+
+  def profiles
+    meta[DIRECTORY_META[:profiles]]
   end
 
   def meta

--- a/lib/acme/client/resources/order.rb
+++ b/lib/acme/client/resources/order.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Acme::Client::Resources::Order
-  attr_reader :url, :status, :contact, :finalize_url, :identifiers, :authorization_urls, :expires, :certificate_url
+  attr_reader :url, :status, :contact, :finalize_url, :identifiers, :authorization_urls, :expires, :certificate_url, :profile
 
   def initialize(client, **arguments)
     @client = client
@@ -44,13 +44,14 @@ class Acme::Client::Resources::Order
       finalize_url: finalize_url,
       authorization_urls: authorization_urls,
       identifiers: identifiers,
-      certificate_url: certificate_url
+      certificate_url: certificate_url,
+      profile: profile
     }
   end
 
   private
 
-  def assign_attributes(url: nil, status:, expires:, finalize_url:, authorization_urls:, identifiers:, certificate_url: nil)
+  def assign_attributes(url: nil, status:, expires:, finalize_url:, authorization_urls:, identifiers:, certificate_url: nil, profile: nil) # rubocop:disable Layout/LineLength,Metrics/ParameterLists
     @url = url
     @status = status
     @expires = expires
@@ -58,5 +59,6 @@ class Acme::Client::Resources::Order
     @authorization_urls = authorization_urls
     @identifiers = identifiers
     @certificate_url = certificate_url
+    @profile = profile
   end
 end

--- a/spec/cassettes/directory_meta.yml
+++ b/spec/cassettes/directory_meta.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Acme::Client v2.0.15 (https://github.com/unixcharles/acme-client)
+      - Acme::Client v2.0.24 (https://github.com/unixcharles/acme-client)
       Content-Type:
       - application/jose+json
       Accept-Encoding:
@@ -20,39 +20,56 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 07 Aug 2025 00:03:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1069'
+      Connection:
+      - keep-alive
       Cache-Control:
       - public, max-age=0, no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 16 Jan 2024 18:10:51 GMT
-      Content-Length:
-      - '396'
+      X-Frame-Options:
+      - DENY
+      Strict-Transport-Security:
+      - max-age=604800
     body:
       encoding: UTF-8
       string: |-
         {
-           "keyChange": "<DIRECTORY_BASE_URL>/rollover-account-key",
-           "meta": {
-              "externalAccountRequired": false,
-              "termsOfService": "data:text/plain,Do%20what%20thou%20wilt"
-           },
-           "newAccount": "<DIRECTORY_BASE_URL>/sign-me-up",
-           "newNonce": "<DIRECTORY_BASE_URL>/nonce-plz",
-           "newOrder": "<DIRECTORY_BASE_URL>/order-plz",
-           "revokeCert": "<DIRECTORY_BASE_URL>/revoke-cert"
+          "7G1fvuN7_Ag": "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417",
+          "keyChange": "<DIRECTORY_BASE_URL>/acme/key-change",
+          "meta": {
+            "caaIdentities": [
+              "letsencrypt.org"
+            ],
+            "profiles": {
+              "classic": "https://letsencrypt.org/docs/profiles#classic",
+              "shortlived": "https://letsencrypt.org/docs/profiles#shortlived (not yet generally available)",
+              "tlsserver": "https://letsencrypt.org/docs/profiles#tlsserver"
+            },
+            "termsOfService": "https://letsencrypt.org/documents/LE-SA-v1.5-February-24-2025.pdf",
+            "website": "https://letsencrypt.org/docs/staging-environment/"
+          },
+          "newAccount": "<DIRECTORY_BASE_URL>/acme/new-acct",
+          "newNonce": "<DIRECTORY_BASE_URL>/acme/new-nonce",
+          "newOrder": "<DIRECTORY_BASE_URL>/acme/new-order",
+          "renewalInfo": "<DIRECTORY_BASE_URL>/acme/renewal-info",
+          "revokeCert": "<DIRECTORY_BASE_URL>/acme/revoke-cert"
         }
-    http_version:
-  recorded_at: Tue, 16 Jan 2024 18:10:51 GMT
+  recorded_at: Thu, 07 Aug 2025 00:03:18 GMT
 - request:
     method: head
-    uri: "<DIRECTORY_BASE_URL>/nonce-plz"
+    uri: "<DIRECTORY_BASE_URL>/acme/new-nonce"
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Acme::Client v2.0.15 (https://github.com/unixcharles/acme-client)
+      - Acme::Client v2.0.24 (https://github.com/unixcharles/acme-client)
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -62,28 +79,35 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 07 Aug 2025 00:03:18 GMT
+      Connection:
+      - keep-alive
       Cache-Control:
       - public, max-age=0, no-cache
       Link:
       - <<DIRECTORY_URL>>;rel="index"
       Replay-Nonce:
-      - Tuty2P8DM9lQfIoWYI_xIA
-      Date:
-      - Tue, 16 Jan 2024 18:10:51 GMT
+      - ALP4o33PV4DYny9QNudkQ3PifpsjGtherdY0XtqivctWeSSRZt8
+      X-Frame-Options:
+      - DENY
+      Strict-Transport-Security:
+      - max-age=604800
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Tue, 16 Jan 2024 18:10:51 GMT
+  recorded_at: Thu, 07 Aug 2025 00:03:18 GMT
 - request:
     method: post
-    uri: "<DIRECTORY_BASE_URL>/sign-me-up"
+    uri: "<DIRECTORY_BASE_URL>/acme/new-acct"
     body:
       encoding: UTF-8
-      string: '{"protected":"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCIsIm5vbmNlIjoiVHV0eTJQOERNOWxRZklvV1lJX3hJQSIsInVybCI6Imh0dHBzOi8vMC4wLjAuMDoxNDAwMC9zaWduLW1lLXVwIiwiandrIjp7ImNydiI6IlAtMzg0Iiwia3R5IjoiRUMiLCJ4IjoiNkZ2SzNfZ3Ywei1mZ250b0VRQWFmUGxpZHVxUXd0QlpsMGdqTDRzc2ltdm5Cd0M4aWxYVlBiLWNNTlBxaFEwaSIsInkiOiJla2lEa29YTVlXTmhvSWwydTRUcEg2U3oyOXlXMkZpMm1qenhBYVRzTGpQczVIMnhQWW1GYlBRRmF1N3EzejVQIn19","payload":"eyJjb250YWN0IjpbIm1haWx0bzppbmZvQGV4YW1wbGUuY29tIl0sInRlcm1zT2ZTZXJ2aWNlQWdyZWVkIjp0cnVlfQ","signature":"TD8n-T2m1qE1mo9uZTl7AJax1D1LclTBixqXZmeyQi7xXQjSeGWdtBPpjvE6d0kCSpQNGv6GcBJgYHS-QoK-z-4YQnCDggCMetyn2d9MFeYuqiEhM9XrULchX58ZmiFe"}'
+      string: '{"protected":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIm5vbmNlIjoiQUxQNG8zM1BWNERZbnk5UU51ZGtRM1BpZnBzakd0aGVyZFkwWHRxaXZjdFdlU1NSWnQ4IiwidXJsIjoiaHR0cHM6Ly9hY21lLXN0YWdpbmctdjAyLmFwaS5sZXRzZW5jcnlwdC5vcmcvYWNtZS9uZXctYWNjdCIsImp3ayI6eyJlIjoiQVFBQiIsImt0eSI6IlJTQSIsIm4iOiJrSXd6cWg1MlhibnRndHVrMUY0TnVDSjN3MUtIa3NjU0lUejR2UHd5V0lJd0U3b2x0VGZNMjZYY2pfNXpDNFpTNm5GUXF2YnVxaUh0bEJTOGlsWWlfd1hadllvNDdXWmRnMF9RRi0xYmdDV2wxc2VpYXhSY2RUWThfMXBmMlZWOUUwZ3AwVzdyREp3eDRwVEtQQUlfcWE4SG9VZXVqZ1RYLXBJd0ZtNlYxV1dDZmM1RWxETEVYQmprQ2NsUmk2LTFMZjJUZi1IT1N3OWVvWExCTnNZZ2JGbTFqZmoxeUhSeHZ6b0N0WmRpYWJpTnBDbEdPSlJZV0x2MzhjV25nMHNfeFgtckhxejZrTUsycmtuSDdXZjFyYS1ndVo4N2Zqbl9OZGd5TFJyTzc5TU9Eb29PT3ZBekpyRGhwQ0lQTmZENFlOM21YZzZXV3B1UEp0SnpHc1NUZXcifX0","payload":"eyJjb250YWN0IjpbIm1haWx0bzppbmZvQDQzMDgxNmRlZGNiOWQ1ZmE3NWY1ZTljMjMxZjMyYzM0LWV4YW1wbGUuY29tIl0sInRlcm1zT2ZTZXJ2aWNlQWdyZWVkIjp0cnVlfQ","signature":"SIurq4ua2Cq1EFCmUx527gHIYLXu7ZeoWps_tUiaRrW4M80_UQxp4CLGL5gAKweE3xhrhDB54jYHHuKYt_2DiBbIIQ8UcO-okt9KG0btWjN47J2HSBA3EaZQt1aIR2_PSve-uED8b1YgzDSpIkEIt0fSxrvk93gA5rtMriIUgy0-8iiiUarV9YchTocDJEnEM4MG93c0YX0QEhE5oRnIAUAgVsP5pcQOyafmhCQPmpbYUXNDcyX-tT0TfA5Hp9ciCtzKb-0J77G0h4n9cWrSxF-Xnu7wcXCCUX5ZtCI_R0DbWtkzFeU2ObbO8JS3gp9SvMRtFo3hM13bZGBljGBEJw"}'
     headers:
       User-Agent:
-      - Acme::Client v2.0.15 (https://github.com/unixcharles/acme-client)
+      - Acme::Client v2.0.24 (https://github.com/unixcharles/acme-client)
       Content-Type:
       - application/jose+json
       Accept-Encoding:
@@ -95,36 +119,42 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 07 Aug 2025 00:03:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '477'
+      Connection:
+      - keep-alive
+      Boulder-Requester:
+      - '218860643'
       Cache-Control:
       - public, max-age=0, no-cache
-      Content-Type:
-      - application/json; charset=utf-8
       Link:
       - <<DIRECTORY_URL>>;rel="index"
+      - <https://letsencrypt.org/documents/LE-SA-v1.5-February-24-2025.pdf>;rel="terms-of-service"
       Location:
-      - "<DIRECTORY_BASE_URL>/my-account/4530875a31aa979c"
+      - "<DIRECTORY_BASE_URL>/acme/acct/218860643"
       Replay-Nonce:
-      - wgZvnNCEXH7AO9RaizC3Tw
-      Date:
-      - Tue, 16 Jan 2024 18:10:51 GMT
-      Content-Length:
-      - '361'
+      - tqu6ViAuxdoFl38R7avi6ln3cAC9iCH0orClXVo9s1GK1TqgkzA
+      X-Frame-Options:
+      - DENY
+      Strict-Transport-Security:
+      - max-age=604800
     body:
       encoding: UTF-8
       string: |-
         {
-           "status": "valid",
-           "contact": [
-              "mailto:info@example.com"
-           ],
-           "orders": "<DIRECTORY_BASE_URL>/list-orderz/4530875a31aa979c",
-           "key": {
-              "kty": "EC",
-              "crv": "P-384",
-              "x": "6FvK3_gv0z-fgntoEQAafPliduqQwtBZl0gjL4ssimvnBwC8ilXVPb-cMNPqhQ0i",
-              "y": "ekiDkoXMYWNhoIl2u4TpH6Sz29yW2Fi2mjzxAaTsLjPs5H2xPYmFbPQFau7q3z5P"
-           }
+          "key": {
+            "kty": "RSA",
+            "n": "kIwzqh52Xbntgtuk1F4NuCJ3w1KHkscSITz4vPwyWIIwE7oltTfM26Xcj_5zC4ZS6nFQqvbuqiHtlBS8ilYi_wXZvYo47WZdg0_QF-1bgCWl1seiaxRcdTY8_1pf2VV9E0gp0W7rDJwx4pTKPAI_qa8HoUeujgTX-pIwFm6V1WWCfc5ElDLEXBjkCclRi6-1Lf2Tf-HOSw9eoXLBNsYgbFm1jfj1yHRxvzoCtZdiabiNpClGOJRYWLv38cWng0s_xX-rHqz6kMK2rknH7Wf1ra-guZ87fjn_NdgyLRrO79MODooOOvAzJrDhpCIPNfD4YN3mXg6WWpuPJtJzGsSTew",
+            "e": "AQAB"
+          },
+          "createdAt": "2025-08-07T00:03:19.073480281Z",
+          "status": "valid"
         }
-    http_version:
-  recorded_at: Tue, 16 Jan 2024 18:10:51 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Thu, 07 Aug 2025 00:03:19 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/order_profile.yml
+++ b/spec/cassettes/order_profile.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 07 Aug 2025 02:10:49 GMT
+      - Wed, 06 Aug 2025 23:55:43 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -40,7 +40,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "14mj2SWIKHA": "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417",
+          "INxHBqKTr80": "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417",
           "keyChange": "<DIRECTORY_BASE_URL>/acme/key-change",
           "meta": {
             "caaIdentities": [
@@ -60,7 +60,7 @@ http_interactions:
           "renewalInfo": "<DIRECTORY_BASE_URL>/acme/renewal-info",
           "revokeCert": "<DIRECTORY_BASE_URL>/acme/revoke-cert"
         }
-  recorded_at: Thu, 07 Aug 2025 02:10:49 GMT
+  recorded_at: Wed, 06 Aug 2025 23:55:43 GMT
 - request:
     method: head
     uri: "<DIRECTORY_BASE_URL>/acme/new-nonce"
@@ -82,7 +82,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 07 Aug 2025 02:10:49 GMT
+      - Wed, 06 Aug 2025 23:55:43 GMT
       Connection:
       - keep-alive
       Cache-Control:
@@ -90,7 +90,7 @@ http_interactions:
       Link:
       - <<DIRECTORY_URL>>;rel="index"
       Replay-Nonce:
-      - tqu6ViAuNruNktPXoHrZ-MO6XY_ggBo_2JvCx1loq8TX-aqBsfM
+      - tqu6ViAuVUFleMvdiiWH6JdtBQzUqc6c7JhBCRuN16Xz_jO_h0w
       X-Frame-Options:
       - DENY
       Strict-Transport-Security:
@@ -98,13 +98,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Thu, 07 Aug 2025 02:10:49 GMT
+  recorded_at: Wed, 06 Aug 2025 23:55:43 GMT
 - request:
     method: post
     uri: "<DIRECTORY_BASE_URL>/acme/new-acct"
     body:
       encoding: UTF-8
-      string: '{"protected":"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCIsIm5vbmNlIjoidHF1NlZpQXVOcnVOa3RQWG9IclotTU82WFlfZ2dCb18ySnZDeDFsb3E4VFgtYXFCc2ZNIiwidXJsIjoiaHR0cHM6Ly9hY21lLXN0YWdpbmctdjAyLmFwaS5sZXRzZW5jcnlwdC5vcmcvYWNtZS9uZXctYWNjdCIsImp3ayI6eyJjcnYiOiJQLTM4NCIsImt0eSI6IkVDIiwieCI6Ik9WNUtPTURDNUNVY0cyc05TZ0RjSmhYR2U4OHRYOF92NENISGFHSlM4V01Nd1c5M1hxN2duLTRLU2thRHhGVWUiLCJ5Ijoibkx1eDJJRmVvYV9NY1lPWHJVbW1iRFZCd2F1bXNkSG5hNEQ4VmlLY3dZcUZNcVZFbEhiT25tVDMxNDVVX1J5NiJ9fQ","payload":"eyJjb250YWN0IjpbIm1haWx0bzppbmZvQDY5YTFlOWFkNjhmYTkwM2MxM2ZjODRjODlmMmIwYmYzLWV4YW1wbGUuY29tIl0sInRlcm1zT2ZTZXJ2aWNlQWdyZWVkIjp0cnVlfQ","signature":"uy13T1DGyS-4Om3tVY3XahT6OorAECoFe2obzCw9CdEGQZav6RbuIrgdp3eYfbP1E9blLcxV-X91OhDAgKppYquGRdf1-uuD83VWAX_oRJrEF7bIylUr50CnWUYkzyPs"}'
+      string: '{"protected":"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsIm5vbmNlIjoidHF1NlZpQXVWVUZsZU12ZGlpV0g2SmR0QlF6VXFjNmM3SmhCQ1J1TjE2WHpfak9faDB3IiwidXJsIjoiaHR0cHM6Ly9hY21lLXN0YWdpbmctdjAyLmFwaS5sZXRzZW5jcnlwdC5vcmcvYWNtZS9uZXctYWNjdCIsImp3ayI6eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6Im83TWlxNDlaQXJyWEJHVXk5M2JQQm40V3Q4VnltWEd0TnpMQmFZZWRxVTgiLCJ5IjoiUWZ6a0kxN3dJdE1MUkZSVUVFWGdiZXk2MXNEUVhrWkQ1OUJ2Q0xNbVU5WSJ9fQ","payload":"eyJjb250YWN0IjpbIm1haWx0bzppbmZvQDQ3MzMxYmM3NjdkMGJiODEzMDY0ZGRjZDYwNmJmNDJmLWV4YW1wbGUuY29tIl0sInRlcm1zT2ZTZXJ2aWNlQWdyZWVkIjp0cnVlfQ","signature":"g2faI2x868rJmwrBNkOadRsFLX9paH-7yhmDsCBAAQ4k2NImCmN8BKNj8lWONP0dS1wFu4P4aMA0TBkD85CbAQ"}'
     headers:
       User-Agent:
       - Acme::Client v2.0.24 (https://github.com/unixcharles/acme-client)
@@ -122,24 +122,24 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 07 Aug 2025 02:10:50 GMT
+      - Wed, 06 Aug 2025 23:55:44 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '278'
+      - '236'
       Connection:
       - keep-alive
       Boulder-Requester:
-      - '218946143'
+      - '218839203'
       Cache-Control:
       - public, max-age=0, no-cache
       Link:
       - <<DIRECTORY_URL>>;rel="index"
       - <https://letsencrypt.org/documents/LE-SA-v1.5-February-24-2025.pdf>;rel="terms-of-service"
       Location:
-      - "<DIRECTORY_BASE_URL>/acme/acct/218946143"
+      - "<DIRECTORY_BASE_URL>/acme/acct/218839203"
       Replay-Nonce:
-      - ALP4o33PUQqxriD0Th-hG-12iQi4qXaYaGf1kO1jHhGg2EMYQE0
+      - ALP4o33PcEg13YyV1ukzwpaQJ5Ea9v9ETHBxXAHqyJNFE6c9aTI
       X-Frame-Options:
       - DENY
       Strict-Transport-Security:
@@ -150,12 +150,75 @@ http_interactions:
         {
           "key": {
             "kty": "EC",
-            "crv": "P-384",
-            "x": "OV5KOMDC5CUcG2sNSgDcJhXGe88tX8_v4CHHaGJS8WMMwW93Xq7gn-4KSkaDxFUe",
-            "y": "nLux2IFeoa_McYOXrUmmbDVBwaumsdHna4D8ViKcwYqFMqVElHbOnmT3145U_Ry6"
+            "crv": "P-256",
+            "x": "o7Miq49ZArrXBGUy93bPBn4Wt8VymXGtNzLBaYedqU8",
+            "y": "QfzkI17wItMLRFRUEEXgbey61sDQXkZD59BvCLMmU9Y"
           },
-          "createdAt": "2025-08-07T02:10:50.186269579Z",
+          "createdAt": "2025-08-06T23:55:44.236296447Z",
           "status": "valid"
         }
-  recorded_at: Thu, 07 Aug 2025 02:10:50 GMT
+  recorded_at: Wed, 06 Aug 2025 23:55:44 GMT
+- request:
+    method: post
+    uri: "<DIRECTORY_BASE_URL>/acme/new-order"
+    body:
+      encoding: UTF-8
+      string: '{"protected":"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsIm5vbmNlIjoiQUxQNG8zM1BjRWcxM1l5VjF1a3p3cGFRSjVFYTl2OUVUSEJ4WEFIcXlKTkZFNmM5YVRJIiwidXJsIjoiaHR0cHM6Ly9hY21lLXN0YWdpbmctdjAyLmFwaS5sZXRzZW5jcnlwdC5vcmcvYWNtZS9uZXctb3JkZXIiLCJraWQiOiJodHRwczovL2FjbWUtc3RhZ2luZy12MDIuYXBpLmxldHNlbmNyeXB0Lm9yZy9hY21lL2FjY3QvMjE4ODM5MjAzIn0","payload":"eyJpZGVudGlmaWVycyI6W3sidHlwZSI6ImRucyIsInZhbHVlIjoiNDczMzFiYzc2N2QwYmI4MTMwNjRkZGNkNjA2YmY0MmYtZXhhbXBsZS5jb20ifV0sInByb2ZpbGUiOiJzaG9ydGxpdmVkIn0","signature":"3w1yaLbnEEbbZ0DC8LwujTdtyQzoFwE9k9W_FAaBHrf-Jw25afy8OHVYfkit3bk0peeD_QNVvSw2kXrXcD29Rw"}'
+    headers:
+      User-Agent:
+      - Acme::Client v2.0.24 (https://github.com/unixcharles/acme-client)
+      Content-Type:
+      - application/jose+json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 06 Aug 2025 23:55:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '417'
+      Connection:
+      - keep-alive
+      Boulder-Requester:
+      - '218839203'
+      Cache-Control:
+      - public, max-age=0, no-cache
+      Link:
+      - <<DIRECTORY_URL>>;rel="index"
+      Location:
+      - "<DIRECTORY_BASE_URL>/acme/order/218839203/26495704013"
+      Replay-Nonce:
+      - tqu6ViAuI3zF5957UCuBkMLd79z5gdT4a9LThfsunbjJipdCPVA
+      X-Frame-Options:
+      - DENY
+      Strict-Transport-Security:
+      - max-age=604800
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "status": "pending",
+          "expires": "2025-08-07T00:55:44Z",
+          "identifiers": [
+            {
+              "type": "dns",
+              "value": "<EXAMPLE_DOMAIN>"
+            }
+          ],
+          "authorizations": [
+            "<DIRECTORY_BASE_URL>/acme/authz/218839203/18831548173"
+          ],
+          "finalize": "<DIRECTORY_BASE_URL>/acme/finalize/218839203/26495704013",
+          "profile": "shortlived"
+        }
+  recorded_at: Wed, 06 Aug 2025 23:55:44 GMT
 recorded_with: VCR 6.3.1

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -11,7 +11,7 @@ describe Acme::Client do
   let(:unregistered_client) { Acme::Client.new(private_key: private_key, directory: DIRECTORY_URL) }
   let(:client) do
     client = Acme::Client.new(private_key: private_key, directory: DIRECTORY_URL)
-    client.new_account(contact: 'mailto:info@example.com', terms_of_service_agreed: true)
+    client.new_account(contact: "mailto:info@#{EXAMPLE_DOMAIN}", terms_of_service_agreed: true)
     client
   end
 
@@ -50,6 +50,7 @@ describe Acme::Client do
     it { expect(client.meta).to be_a(Hash) }
     it { expect(client.terms_of_service).to be_a(String) }
     it { expect(client.external_account_required).to be_nil }
+    it { expect(client.profiles).to be_a_kind_of(Hash) }
   end
 
   context 'account operation' do

--- a/spec/directory_spec.rb
+++ b/spec/directory_spec.rb
@@ -4,7 +4,7 @@ describe Acme::Client::Resources::Directory do
   let(:private_key) { generate_private_key }
   let(:client) do
     client = Acme::Client.new(private_key: private_key, directory: DIRECTORY_URL)
-    client.new_account(contact: 'mailto:info@example.com', terms_of_service_agreed: true)
+    client.new_account(contact: "mailto:info@#{EXAMPLE_DOMAIN}", terms_of_service_agreed: true)
     client
   end
 
@@ -29,6 +29,7 @@ describe Acme::Client::Resources::Directory do
   context 'meta', vcr: { cassette_name: 'directory_meta' } do
     it { expect(directory.meta).to be_a(Hash) }
     it { expect(directory.terms_of_service).to be_a(String) }
-    it { expect(directory.external_account_required).to be false }
+    it { expect(directory.external_account_required).to be nil }
+    it { expect(directory.profiles).to be_a_kind_of(Hash) }
   end
 end

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -4,18 +4,28 @@ describe Acme::Client::Resources::Order do
   let(:private_key) { generate_private_key }
   let(:unregistered_client) do
     client = Acme::Client.new(private_key: private_key, directory: DIRECTORY_URL)
-    client.new_account(contact: 'mailto:info@example.com', terms_of_service_agreed: true)
+    client.new_account(contact: "mailto:info@#{EXAMPLE_DOMAIN}", terms_of_service_agreed: true)
     client
   end
 
   let(:client) do
     client = Acme::Client.new(private_key: private_key, directory: DIRECTORY_URL)
-    client.new_account(contact: 'mailto:info@example.com', terms_of_service_agreed: true)
+    client.new_account(contact: "mailto:info@#{EXAMPLE_DOMAIN}", terms_of_service_agreed: true)
     client
   end
 
   let(:order) do
     client.new_order(identifiers: [{ type: 'dns', value: 'example.com' }])
+  end
+
+  context 'profile' do
+    let(:order) do
+      client.new_order(identifiers: [{ type: 'dns', value: EXAMPLE_DOMAIN }], profile: 'shortlived')
+    end
+
+    it 'call client open with a profile', vcr: { cassette_name: 'order_profile' } do
+      expect(order.profile).to eq('shortlived')
+    end
   end
 
   context 'status' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,10 @@ $LOAD_PATH.unshift File.join(__dir__, '../lib')
 $LOAD_PATH.unshift File.join(__dir__, 'support')
 
 require 'openssl'
+require 'securerandom'
 
 DIRECTORY_URL = ENV['ACME_DIRECTORY_URL'] || 'https://127.0.0.1/directory'
+EXAMPLE_DOMAIN = ENV['EXAMPLE_DOMAIN'] || "#{SecureRandom.hex}-example.com"
 
 require 'acme/client'
 
@@ -38,5 +40,8 @@ VCR.configure do |c|
   end
   c.filter_sensitive_data('<DIRECTORY_BASE_URL>') do
     DIRECTORY_URL.gsub(%r[\/[^\/]+$], '')
+  end
+  c.filter_sensitive_data('<EXAMPLE_DOMAIN>') do
+    EXAMPLE_DOMAIN
   end
 end


### PR DESCRIPTION
Add support for [Automated Certificate Management Environment (ACME) Profiles Extension](https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/). This ACME extension is supported by LetsEncrypt (both Boulder & Pebble). The directory resource can now include a `"profiles"` object that is accessible from the `Acme::Client#profiles` method, which returns a `Hash` of profile names to human-readable descriptions of the profile. A profile can be specified by name when creating an order with `Acme::Client#new_order`. The README has been updated with a section on usage for both.

Since the test cassettes were last recorded, LetsEncrypt's staging instance blocks emails from the `example.com` & `example.org` domains. To get around this, I've added the `EXAMPLE_DOMAIN` environment variable into some of the specs, and re-recorded some cassettes.