### PR TITLE
ARI related improvements

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -224,13 +224,18 @@ class Acme::Client
     response.success?
   end
 
-  def renewal_info(certificate:)
-    cert_id = Acme::Client::Util.ari_certificate_identifier(certificate)
-    renewal_info_url = URI.join(endpoint_for(:renewal_info).to_s + '/', cert_id).to_s
+  def renewal_info(certificate: nil, ari_id: nil)
+    if certificate.nil? && ari_id.nil?
+      raise ArgumentError, 'must specify certificate or ari_id'
+    end
+
+    ari_id ||= Acme::Client::Util.ari_certificate_identifier(certificate)
+
+    renewal_info_url = URI.join(endpoint_for(:renewal_info).to_s + '/', ari_id).to_s
 
     response = get(renewal_info_url)
     attributes = attributes_from_renewal_info_response(response)
-    Acme::Client::Resources::RenewalInfo.new(self, **attributes)
+    Acme::Client::Resources::RenewalInfo.new(self, ari_id: ari_id, **attributes)
   end
 
   def get_nonce

--- a/lib/acme/client/resources/order.rb
+++ b/lib/acme/client/resources/order.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Acme::Client::Resources::Order
-  attr_reader :url, :status, :contact, :finalize_url, :identifiers, :authorization_urls, :expires, :certificate_url, :profile
+  attr_reader :url, :status, :contact, :finalize_url, :identifiers, :authorization_urls, :expires, :certificate_url, :profile, :replaces
 
   def initialize(client, **arguments)
     @client = client
@@ -36,6 +36,18 @@ class Acme::Client::Resources::Order
     end
   end
 
+  def renew(replaces: nil, **arguments)
+    replaces ||= renewal_info.ari_id
+
+    @client.new_order(replaces: replaces, **to_h.slice(:identifiers, :profile).merge(arguments))
+  end
+
+  def renewal_info(certificate: nil, ari_id: nil)
+    certificate ||= self.certificate if ari_id.nil?
+
+    @client.renewal_info(certificate:, ari_id:)
+  end
+
   def to_h
     {
       url: url,
@@ -45,13 +57,14 @@ class Acme::Client::Resources::Order
       authorization_urls: authorization_urls,
       identifiers: identifiers,
       certificate_url: certificate_url,
-      profile: profile
+      profile: profile,
+      replaces: replaces
     }
   end
 
   private
 
-  def assign_attributes(url: nil, status:, expires:, finalize_url:, authorization_urls:, identifiers:, certificate_url: nil, profile: nil) # rubocop:disable Layout/LineLength,Metrics/ParameterLists
+  def assign_attributes(url: nil, status:, expires:, finalize_url:, authorization_urls:, identifiers:, certificate_url: nil, profile: nil, replaces: nil) # rubocop:disable Layout/LineLength,Metrics/ParameterLists
     @url = url
     @status = status
     @expires = expires
@@ -60,5 +73,6 @@ class Acme::Client::Resources::Order
     @identifiers = identifiers
     @certificate_url = certificate_url
     @profile = profile
+    @replaces = replaces
   end
 end

--- a/lib/acme/client/resources/renewal_info.rb
+++ b/lib/acme/client/resources/renewal_info.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 class Acme::Client::Resources::RenewalInfo
-  attr_reader :suggested_window, :explanation_url, :retry_after
+  attr_reader :ari_id, :suggested_window, :explanation_url, :retry_after
 
   def initialize(client, **arguments)
     @client = client
     assign_attributes(**arguments)
+  end
+
+  def reload
+    assign_attributes(**@client.renewal_info(ari_id: ari_id).to_h)
   end
 
   def suggested_window_start
@@ -31,6 +35,7 @@ class Acme::Client::Resources::RenewalInfo
 
   def to_h
     {
+      ari_id: ari_id,
       suggested_window: suggested_window,
       explanation_url: explanation_url,
       retry_after: retry_after
@@ -39,7 +44,8 @@ class Acme::Client::Resources::RenewalInfo
 
   private
 
-  def assign_attributes(suggested_window:, explanation_url: nil, retry_after: nil)
+  def assign_attributes(ari_id:, suggested_window:, explanation_url: nil, retry_after: nil)
+    @ari_id = ari_id
     @suggested_window = suggested_window
     @explanation_url = explanation_url
     @retry_after = retry_after

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -28,6 +28,20 @@ describe Acme::Client::Resources::Order do
     end
   end
 
+  context 'replaces' do
+    let(:certificate_pem) { File.read('spec/fixtures/certificate_chain.pem') }
+    let(:ari_id) { Acme::Client::Util.ari_certificate_identifier(certificate_pem) }
+
+    let(:order) do
+      client.new_order(identifiers: [{ type: 'dns', value: EXAMPLE_DOMAIN }], replaces: ari_id)
+    end
+
+    it 'call client open with a replaces ARI identifier', vcr: { cassette_name: 'new_order_with_replaces' } do
+      pending('a way to seed an replaceable order/cert in the CA')
+      expect(order.replaces).to eq(ari_id)
+    end
+  end
+
   context 'status' do
     it 'send the agreement for the terms', vcr: { cassette_name: 'order_status' } do
       expect(order.status).to eq('pending')


### PR DESCRIPTION
We implemented ARI in our internal fork of acme-client. I've been meaning to send a PR but in the mean time @nckslvrmn beat me to it (thanks!), so this is mostly just cosmetic changes that improve the API IMO. Before I get to those, the place I got stuck was how to test this using VCR testing. This is a extra challenge for ARI because the ARI workflow depends on orders & certs to be in the finished state before they can be successfully renewed, and there are also timing issues too. It looks like the recordings for the ARI tests added in #257 don't actually include the ARI information in the [payload](https://github.com/unixcharles/acme-client/pull/257/files#diff-5d2873a89a51d55ac6aadb0c38070eddbf47045bc97655d3c91b986f2aa5e50dR130)[1] or [response](https://github.com/unixcharles/acme-client/pull/257/files#diff-5d2873a89a51d55ac6aadb0c38070eddbf47045bc97655d3c91b986f2aa5e50dR162-R175). (Ditto for the new order request payload in [new_order_already_replaced.yml](https://github.com/unixcharles/acme-client/pull/257/files#diff-072d289a5d58a80e93b1be26fc69d65f85d75a9c5191057562ab43985359ecea).) So these tests could likely cause failures & confusion in the future, but I don't have a real solution, that is why I have marked some tests as "pending" in this PR.

This makes `RenewalInfo` reloadable by tracking the ARI ID value in the renewal info object. It also allows `Client.renewal_info` to accept an ARI ID as an alternative to the certificate object/data. And `Order` now tracks the ARI ID of the certificate the order is replacing in the `replaces` attribute. And finally, `Order#renew` is added as a helper method to easily replace a finished order.

[1] no `"replaces"` field present in the JWS' encoded `"payload"`:
```sh
$ echo 'eyJpZGVudGlmaWVycyI6W3sidHlwZSI6ImRucyIsInZhbHVlIjoiZXhhbXBsZS5jb20ifV19==' | base64 -D
{"identifiers":[{"type":"dns","value":"example.com"}]}
```