### PR TITLE
Rate limited retry after

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -20,6 +20,7 @@ require 'acme/client/self_sign_certificate'
 require 'acme/client/resources'
 require 'acme/client/jwk'
 require 'acme/client/error'
+require 'acme/client/error/rate_limited'
 require 'acme/client/util'
 require 'acme/client/chain_identifier'
 

--- a/lib/acme/client/error/rate_limited.rb
+++ b/lib/acme/client/error/rate_limited.rb
@@ -1,0 +1,8 @@
+class Acme::Client::Error::RateLimited < Acme::Client::Error::ServerError
+  attr_reader :retry_after
+
+  def initialize(message, retry_after = 10)
+    super(message)
+    @retry_after = retry_after.nil? ? 10 : retry_after.to_i
+  end
+end

--- a/lib/acme/client/http_client.rb
+++ b/lib/acme/client/http_client.rb
@@ -101,6 +101,9 @@ module Acme::Client::HTTPClient
     end
 
     def raise_on_error!
+      if error_class == Acme::Client::Error::RateLimited
+        raise error_class.new(error_message, env.response_headers['Retry-After'])
+      end
       raise error_class, error_message
     end
 

--- a/spec/directory_spec.rb
+++ b/spec/directory_spec.rb
@@ -25,6 +25,7 @@ describe Acme::Client::Resources::Directory do
         }.to raise_error(Acme::Client::Error::RateLimited)
       end
     end
+
   end
 
   context 'meta', vcr: { cassette_name: 'directory_meta' } do


### PR DESCRIPTION
Reimplementation of https://github.com/unixcharles/acme-client/pull/127 since it had diverged too far to rebase with any sanity.

I have tested this against a locally-running Boulder instance. Log from Boulder:

```
boulder-1  | 2025-11-27T04:29:32.649950+00:00Z 592f138b0840 unknown boulder-wfe2[488]: 6 boulder-wfe2 3sOhoQQ POST /acme/new-order 1 429 3 0.0.0.0 JSON={"InternalErrors":["too many certificates (2) already issued for this exact set of identifiers in the last 3h0m0s, retry after 2025-11-27 05:06:44 UTC: see https://letsencrypt.org/docs/rate-limits/#new-certificates-per-exact-set-of-identifiers"],"Error":"429 :: rateLimited :: account/ident pair is paused","ua":"Acme::Client v2.0.27 (https://github.com/unixcharles/acme-client)","Identifiers":[{"type":"dns","value":"localtest.website"}]}
```

Log from app:
```
fly-local-web  | [acme-client] RateLimited error - retry after: "2231"
```

So it is indeed functional :) 