### PR TITLE
Avoid defining Object#valid_ip_address?

### DIFF
--- a/lib/acme/client/certificate_request.rb
+++ b/lib/acme/client/certificate_request.rb
@@ -121,15 +121,15 @@ class Acme::Client::CertificateRequest
       )
     )
   end
-end
 
-def valid_ip_address?(address)
-  require 'ipaddr'
-  begin
-    ip = IPAddr.new(address)
-    true
-  rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
-    false
+  def valid_ip_address?(address)
+    require 'ipaddr'
+    begin
+      ip = IPAddr.new(address)
+      true
+    rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
+      false
+    end
   end
 end
 


### PR DESCRIPTION
Looking at cfc29429faab0e278ee1260ad9375bab6549e984, it appears unintentional that this was defined as a top-level method (which makes it a private instance method of Object) and not a method of Acme::Client::CertificateRequest.