### PR TITLE
Add structured ACME problem documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## `2.0.33`
+
+* Add `Acme::Client::Problem` for structured RFC 7807 / RFC 8555 ACME problem documents
+* Expose `Acme::Client::Error#problem` and problem field accessors while keeping `#acme_error_body` behavior
+* Add typed error mappings for all currently registered IANA ACME error types and verify them against IANA's CSV registry
+
 ## `2.0.32`
 
 * Fix `valid_ip_address?` method definition. Was mistakenly defined on Object instead of `Acme::Client::CertificateRequest`

--- a/acme-client.gemspec
+++ b/acme-client.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'vcr', '~> 6.0'
   spec.add_development_dependency 'bigdecimal'
+  spec.add_development_dependency 'csv'
   spec.add_development_dependency 'webmock', '~> 3.8'
   spec.add_development_dependency 'webrick', '~> 1.7'
 

--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -14,6 +14,7 @@ module Acme; end
 class Acme::Client; end
 
 require 'acme/client/version'
+require 'acme/client/problem'
 require 'acme/client/http_client'
 require 'acme/client/certificate_request'
 require 'acme/client/self_sign_certificate'

--- a/lib/acme/client/error.rb
+++ b/lib/acme/client/error.rb
@@ -1,5 +1,7 @@
+require 'acme/client/problem'
+
 class Acme::Client::Error < StandardError
-  attr_reader :retry_after, :retry_after_time, :subproblems, :acme_error_body
+  attr_reader :retry_after, :retry_after_time, :subproblems, :acme_error_body, :problem
 
   Subproblem = Struct.new(:type, :detail, :identifier, keyword_init: true) do
     def to_h
@@ -7,12 +9,13 @@ class Acme::Client::Error < StandardError
     end
   end
 
-  def initialize(message = nil, retry_after: nil, acme_error_body: nil, subproblems: nil)
+  def initialize(message = nil, retry_after: nil, acme_error_body: nil, subproblems: nil, problem: nil)
     super(message)
     @retry_after_time = Acme::Client::Util.parse_retry_after(retry_after)
     @retry_after = @retry_after_time ? [(@retry_after_time - Time.now).ceil, 0].max : nil
-    @acme_error_body = acme_error_body
-    @subproblems = parse_subproblems(subproblems)
+    @problem = Acme::Client::Problem.from(problem || acme_error_body)
+    @acme_error_body = acme_error_body || @problem&.to_h
+    @subproblems = parse_subproblems(subproblems || @problem&.raw_subproblems)
   end
 
   private
@@ -30,6 +33,26 @@ class Acme::Client::Error < StandardError
   end
 
   public
+
+  def type
+    problem&.type
+  end
+
+  def code
+    problem&.code
+  end
+
+  def detail
+    problem&.detail || message
+  end
+
+  def status
+    problem&.status
+  end
+
+  def identifier
+    problem&.identifier
+  end
 
   class Timeout < Acme::Client::Error; end
 
@@ -63,10 +86,17 @@ class Acme::Client::Error < StandardError
   class UserActionRequired < ServerError; end
   class BadRevocationReason < ServerError; end
   class Caa < ServerError; end
+  class Compound < ServerError; end
   class Dns < ServerError; end
   class Connection < ServerError; end
   class Tls < ServerError; end
   class IncorrectResponse < ServerError; end
+  class AutoRenewalCanceled < ServerError; end
+  class AutoRenewalExpired < ServerError; end
+  class AutoRenewalCancellationInvalid < ServerError; end
+  class AutoRenewalRevocationNotSupported < ServerError; end
+  class UnknownDelegation < ServerError; end
+  class OnionCAARequired < ServerError; end
 
   ACME_ERRORS = {
     'urn:ietf:params:acme:error:alreadyReplaced' => AlreadyReplaced,
@@ -89,9 +119,16 @@ class Acme::Client::Error < StandardError
     'urn:ietf:params:acme:error:userActionRequired' => UserActionRequired,
     'urn:ietf:params:acme:error:badRevocationReason' => BadRevocationReason,
     'urn:ietf:params:acme:error:caa' => Caa,
+    'urn:ietf:params:acme:error:compound' => Compound,
     'urn:ietf:params:acme:error:dns' => Dns,
     'urn:ietf:params:acme:error:connection' => Connection,
     'urn:ietf:params:acme:error:tls' => Tls,
-    'urn:ietf:params:acme:error:incorrectResponse' => IncorrectResponse
+    'urn:ietf:params:acme:error:incorrectResponse' => IncorrectResponse,
+    'urn:ietf:params:acme:error:autoRenewalCanceled' => AutoRenewalCanceled,
+    'urn:ietf:params:acme:error:autoRenewalExpired' => AutoRenewalExpired,
+    'urn:ietf:params:acme:error:autoRenewalCancellationInvalid' => AutoRenewalCancellationInvalid,
+    'urn:ietf:params:acme:error:autoRenewalRevocationNotSupported' => AutoRenewalRevocationNotSupported,
+    'urn:ietf:params:acme:error:unknownDelegation' => UnknownDelegation,
+    'urn:ietf:params:acme:error:onionCAARequired' => OnionCAARequired
   }
 end

--- a/lib/acme/client/error/rate_limited.rb
+++ b/lib/acme/client/error/rate_limited.rb
@@ -2,14 +2,14 @@ class Acme::Client::Error::RateLimited < Acme::Client::Error::ServerError
   DEFAULT_MESSAGE = 'Error message: urn:ietf:params:acme:error:rateLimited'
   DEFAULT_RETRY_SECONDS = 10
 
-  def initialize(message = DEFAULT_MESSAGE, retry_after = nil, acme_error_body: nil, subproblems: nil)
+  def initialize(message = DEFAULT_MESSAGE, retry_after = nil, acme_error_body: nil, subproblems: nil, problem: nil)
     retry_after_time = case retry_after
                        when Time then retry_after
                        when nil then Time.now + DEFAULT_RETRY_SECONDS
                        else Acme::Client::Util.parse_retry_after(retry_after) || Time.now + DEFAULT_RETRY_SECONDS
                        end
     int_retry_after = retry_after.nil? ? DEFAULT_RETRY_SECONDS : [(retry_after_time - Time.now).ceil, 0].max
-    super(message, retry_after: int_retry_after, acme_error_body: acme_error_body, subproblems: subproblems)
+    super(message, retry_after: int_retry_after, acme_error_body: acme_error_body, subproblems: subproblems, problem: problem)
     @retry_after_time = retry_after_time
   end
 end

--- a/lib/acme/client/http_client.rb
+++ b/lib/acme/client/http_client.rb
@@ -103,11 +103,12 @@ module Acme::Client::HTTPClient
     def raise_on_error!
       retry_after = env.response_headers['retry-after']
       body = env.body.is_a?(Hash) ? env.body : nil
+      problem = Acme::Client::Problem.from(body)
       subproblems = error_subproblems
       if error_class == Acme::Client::Error::RateLimited
-        raise error_class.new(error_message, retry_after, acme_error_body: body, subproblems: subproblems)
+        raise error_class.new(error_message, retry_after, acme_error_body: body, subproblems: subproblems, problem: problem)
       end
-      raise error_class.new(error_message, retry_after: retry_after, acme_error_body: body, subproblems: subproblems)
+      raise error_class.new(error_message, retry_after: retry_after, acme_error_body: body, subproblems: subproblems, problem: problem)
     end
 
     def error_message

--- a/lib/acme/client/problem.rb
+++ b/lib/acme/client/problem.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module Acme; end
+class Acme::Client; end
+
+class Acme::Client::Problem
+  ERROR_PREFIX = 'urn:ietf:params:acme:error:'.freeze
+
+  # Registry descriptions for problem types, not fallback values for problem details.
+  REGISTERED_ERROR_TYPE_DESCRIPTIONS = {
+    'accountDoesNotExist' => 'The request specified an account that does not exist',
+    'alreadyRevoked' => 'The request specified a certificate to be revoked that has already been revoked',
+    'badCSR' => 'The CSR is unacceptable (e.g., due to a short key)',
+    'badNonce' => 'The client sent an unacceptable anti-replay nonce',
+    'badPublicKey' => 'The JWS was signed by a public key the server does not support',
+    'badRevocationReason' => 'The revocation reason provided is not allowed by the server',
+    'badSignatureAlgorithm' => 'The JWS was signed with an algorithm the server does not support',
+    'caa' => 'Certification Authority Authorization (CAA) records forbid the CA from issuing a certificate',
+    'compound' => 'Specific error conditions are indicated in the "subproblems" array',
+    'connection' => 'The server could not connect to validation target',
+    'dns' => 'There was a problem with a DNS query during identifier validation',
+    'externalAccountRequired' => 'The request must include a value for the "externalAccountBinding" field',
+    'incorrectResponse' => "Response received didn't match the challenge's requirements",
+    'invalidContact' => 'A contact URL for an account was invalid',
+    'malformed' => 'The request message was malformed',
+    'orderNotReady' => 'The request attempted to finalize an order that is not ready to be finalized',
+    'rateLimited' => 'The request exceeds a rate limit',
+    'rejectedIdentifier' => 'The server will not issue certificates for the identifier',
+    'serverInternal' => 'The server experienced an internal error',
+    'tls' => 'The server received a TLS error during validation',
+    'unauthorized' => 'The client lacks sufficient authorization',
+    'unsupportedContact' => 'A contact URL for an account used an unsupported protocol scheme',
+    'unsupportedIdentifier' => 'An identifier is of an unsupported type',
+    'userActionRequired' => 'Visit the "instance" URL and take actions specified there',
+    'autoRenewalCanceled' => 'The short-term certificate is no longer available because the auto-renewal Order has been explicitly canceled by the IdO',
+    'autoRenewalExpired' => 'The short-term certificate is no longer available because the auto-renewal Order has expired',
+    'autoRenewalCancellationInvalid' => 'A request to cancel an auto-renewal Order that is not in state "valid" has been received',
+    'autoRenewalRevocationNotSupported' => 'A request to revoke an auto-renewal Order has been received',
+    'unknownDelegation' => 'An unknown configuration is listed in the delegation attribute of the order request',
+    'onionCAARequired' => 'The CA only supports checking the CAA for Hidden Services in-band, but the client has not provided an in-band CAA',
+    'alreadyReplaced' => 'The request specified a predecessor certificate that has already been marked as replaced'
+  }.freeze
+
+  def self.from(value)
+    case value
+    when nil
+      nil
+    when Acme::Client::Problem
+      value
+    when Hash
+      new(value)
+    end
+  end
+
+  attr_reader :raw
+
+  def initialize(raw = {})
+    @raw = raw || {}
+  end
+
+  def type
+    fetch('type')
+  end
+
+  def code
+    return unless type
+    return unless type.start_with?(ERROR_PREFIX)
+
+    type[ERROR_PREFIX.length..-1]
+  end
+
+  def title
+    fetch('title')
+  end
+
+  def detail
+    fetch('detail')
+  end
+
+  def status
+    fetch('status')
+  end
+
+  def instance
+    fetch('instance')
+  end
+
+  def identifier
+    fetch('identifier')
+  end
+
+  def subproblems
+    return [] unless raw_subproblems.is_a?(Array)
+
+    raw_subproblems.map { |subproblem| self.class.new(subproblem) }
+  end
+
+  def raw_subproblems
+    fetch('subproblems')
+  end
+
+  def registered?
+    REGISTERED_ERROR_TYPE_DESCRIPTIONS.key?(code)
+  end
+
+  alias standard? registered?
+
+  def description
+    REGISTERED_ERROR_TYPE_DESCRIPTIONS[code]
+  end
+
+  def matches?(type_or_code)
+    candidate = type_or_code.to_s
+    candidate == type || candidate == code || "#{ERROR_PREFIX}#{candidate}" == type
+  end
+
+  def message
+    detail || title || type
+  end
+
+  def to_h
+    raw
+  end
+
+  def as_json(*_arguments)
+    to_h
+  end
+
+  private
+
+  def fetch(key)
+    raw[key] || raw[key.to_sym]
+  end
+end

--- a/lib/acme/client/resources/challenges/base.rb
+++ b/lib/acme/client/resources/challenges/base.rb
@@ -31,10 +31,11 @@ class Acme::Client::Resources::Challenges::Base
   def typed_error
     return nil unless error
 
-    error_type = error['type']
-    error_detail = error['detail'] || 'Unknown error'
+    problem = Acme::Client::Problem.from(error)
+    error_type = problem&.type
+    error_detail = problem&.detail || 'Unknown error'
     error_class = Acme::Client::Error::ACME_ERRORS.fetch(error_type, Acme::Client::Error)
-    error_class.new(error_detail)
+    error_class.new(error_detail, problem: problem)
   end
 
   def to_h

--- a/spec/acme_error_body_spec.rb
+++ b/spec/acme_error_body_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'Full problem document (acme_error_body) support' do
     it 'exposes the full problem document when provided' do
       error = Acme::Client::Error.new('rate limited', acme_error_body: problem_document)
       expect(error.acme_error_body).to eq(problem_document)
+      expect(error.problem).to be_a(Acme::Client::Problem)
+      expect(error.problem.to_h).to eq(problem_document)
     end
 
     it 'defaults to nil when not provided' do
@@ -39,11 +41,13 @@ RSpec.describe 'Full problem document (acme_error_body) support' do
     it 'provides access to status from the problem document' do
       error = Acme::Client::Error.new('error', acme_error_body: problem_document)
       expect(error.acme_error_body['status']).to eq(429)
+      expect(error.status).to eq(429)
     end
 
     it 'provides access to instance URL from the problem document' do
       error = Acme::Client::Error.new('error', acme_error_body: problem_document)
       expect(error.acme_error_body['instance']).to eq('https://ca.example.com/acme/error/abc123')
+      expect(error.problem.instance).to eq('https://ca.example.com/acme/error/abc123')
     end
   end
 
@@ -51,6 +55,7 @@ RSpec.describe 'Full problem document (acme_error_body) support' do
     it 'works on ServerError subclasses' do
       error = Acme::Client::Error::Unauthorized.new('unauthorized', acme_error_body: problem_document)
       expect(error.acme_error_body).to eq(problem_document)
+      expect(error.problem.code).to eq('rateLimited')
     end
 
     it 'works on RateLimited with positional args preserved' do
@@ -78,6 +83,7 @@ RSpec.describe 'Full problem document (acme_error_body) support' do
         error = error_class.new('test', acme_error_body: problem_document)
         expect(error.acme_error_body).to eq(problem_document),
           "#{error_class} did not accept acme_error_body correctly"
+        expect(error.problem).to be_a(Acme::Client::Problem)
       end
     end
   end

--- a/spec/problem_spec.rb
+++ b/spec/problem_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.join(__dir__, '../lib')
+
+require 'acme/client'
+
+RSpec.describe Acme::Client::Problem do
+  let(:raw_problem) do
+    {
+      'type' => 'urn:ietf:params:acme:error:unauthorized',
+      'title' => 'Unauthorized',
+      'detail' => 'The client lacks sufficient authorization',
+      'status' => 403,
+      'instance' => 'https://ca.example.test/problems/1',
+      'identifier' => { 'type' => 'dns', 'value' => 'example.test' },
+      'extra' => 'kept'
+    }
+  end
+
+  describe '.from' do
+    it 'wraps hashes' do
+      problem = described_class.from(raw_problem)
+      expect(problem).to be_a(described_class)
+      expect(problem.to_h).to eq(raw_problem)
+    end
+
+    it 'returns existing problems unchanged' do
+      problem = described_class.new(raw_problem)
+      expect(described_class.from(problem)).to equal(problem)
+    end
+
+    it 'returns nil for nil' do
+      expect(described_class.from(nil)).to be_nil
+    end
+  end
+
+  describe 'problem document fields' do
+    subject(:problem) { described_class.new(raw_problem) }
+
+    it 'exposes RFC 7807 fields' do
+      expect(problem.type).to eq('urn:ietf:params:acme:error:unauthorized')
+      expect(problem.title).to eq('Unauthorized')
+      expect(problem.detail).to eq('The client lacks sufficient authorization')
+      expect(problem.status).to eq(403)
+      expect(problem.instance).to eq('https://ca.example.test/problems/1')
+    end
+
+    it 'exposes ACME extension fields' do
+      expect(problem.identifier).to eq({ 'type' => 'dns', 'value' => 'example.test' })
+    end
+
+    it 'keeps the raw problem document for extension fields' do
+      expect(problem.raw['extra']).to eq('kept')
+    end
+  end
+
+  describe '#code' do
+    it 'strips the ACME error prefix for registered ACME problem types' do
+      problem = described_class.new(raw_problem)
+      expect(problem.code).to eq('unauthorized')
+    end
+
+    it 'returns nil for non-ACME problem types' do
+      problem = described_class.new('type' => 'https://ca.example.test/errors/account-blocked')
+      expect(problem.code).to be_nil
+    end
+  end
+
+  describe '#registered?' do
+    it 'returns true for IANA registered ACME error types' do
+      problem = described_class.new('type' => 'urn:ietf:params:acme:error:onionCAARequired')
+      expect(problem).to be_registered
+      expect(problem).to be_standard
+    end
+
+    it 'returns false for unknown ACME error types' do
+      problem = described_class.new('type' => 'urn:ietf:params:acme:error:futureError')
+      expect(problem).not_to be_registered
+      expect(problem).not_to be_standard
+    end
+  end
+
+  describe '#description' do
+    it 'returns the registered description for known ACME error types' do
+      problem = described_class.new('type' => 'urn:ietf:params:acme:error:rateLimited')
+      expect(problem.description).to eq('The request exceeds a rate limit')
+    end
+  end
+
+  describe '#matches?' do
+    subject(:problem) { described_class.new(raw_problem) }
+
+    it 'matches full URNs' do
+      expect(problem.matches?('urn:ietf:params:acme:error:unauthorized')).to be(true)
+    end
+
+    it 'matches short codes' do
+      expect(problem.matches?('unauthorized')).to be(true)
+    end
+
+    it 'does not match other problem types' do
+      expect(problem.matches?('rateLimited')).to be(false)
+    end
+  end
+
+  describe '#subproblems' do
+    it 'parses subproblems as problem objects' do
+      problem = described_class.new(
+        'type' => 'urn:ietf:params:acme:error:compound',
+        'subproblems' => [
+          {
+            'type' => 'urn:ietf:params:acme:error:caa',
+            'detail' => 'CAA forbids issuance',
+            'identifier' => { 'type' => 'dns', 'value' => 'example.test' }
+          }
+        ]
+      )
+
+      expect(problem.subproblems.length).to eq(1)
+      expect(problem.subproblems.first).to be_a(described_class)
+      expect(problem.subproblems.first.code).to eq('caa')
+      expect(problem.subproblems.first.identifier).to eq({ 'type' => 'dns', 'value' => 'example.test' })
+    end
+
+    it 'returns an empty array when subproblems is missing' do
+      expect(described_class.new(raw_problem).subproblems).to eq([])
+    end
+  end
+
+  describe '#message' do
+    it 'prefers detail over title and type' do
+      problem = described_class.new(raw_problem)
+      expect(problem.message).to eq('The client lacks sufficient authorization')
+    end
+
+    it 'falls back to title and type' do
+      expect(described_class.new('title' => 'A title', 'type' => 'about:blank').message).to eq('A title')
+      expect(described_class.new('type' => 'about:blank').message).to eq('about:blank')
+    end
+  end
+
+  describe 'IANA registered ACME error types' do
+    it 'has problem descriptions for each mapped ACME error class' do
+      Acme::Client::Error::ACME_ERRORS.each_key do |type|
+        problem = described_class.new('type' => type)
+        expect(problem.description).not_to be_nil
+      end
+    end
+
+    it 'maps registered extension error types to typed errors' do
+      expect(Acme::Client::Error::ACME_ERRORS['urn:ietf:params:acme:error:compound']).to eq(Acme::Client::Error::Compound)
+      expect(Acme::Client::Error::ACME_ERRORS['urn:ietf:params:acme:error:autoRenewalCanceled']).to eq(Acme::Client::Error::AutoRenewalCanceled)
+      expect(Acme::Client::Error::ACME_ERRORS['urn:ietf:params:acme:error:unknownDelegation']).to eq(Acme::Client::Error::UnknownDelegation)
+      expect(Acme::Client::Error::ACME_ERRORS['urn:ietf:params:acme:error:onionCAARequired']).to eq(Acme::Client::Error::OnionCAARequired)
+    end
+  end
+end

--- a/spec/problem_spec.rb
+++ b/spec/problem_spec.rb
@@ -2,6 +2,10 @@
 
 $LOAD_PATH.unshift File.join(__dir__, '../lib')
 
+require 'csv'
+require 'net/http'
+require 'uri'
+
 require 'acme/client'
 
 RSpec.describe Acme::Client::Problem do
@@ -140,11 +144,72 @@ RSpec.describe Acme::Client::Problem do
   end
 
   describe 'IANA registered ACME error types' do
+    let(:iana_registry) { fetch_iana_acme_error_type_registry }
+
+    def fetch_iana_acme_error_type_registry
+      uri = URI('https://www.iana.org/assignments/acme/acme-error-types.csv')
+
+      response = with_real_http do
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: 5, read_timeout: 10) do |http|
+          http.get(uri.request_uri)
+        end
+      end
+
+      expect(response).to be_a(Net::HTTPSuccess)
+
+      CSV.parse(response.body, headers: true).each_with_object({}) do |row, registry|
+        registry[row['Type']] = normalize_iana_description(row['Description'])
+      end
+    end
+
+    def with_real_http
+      return VCR.turned_off { with_webmock_net_connect { yield } } if defined?(VCR)
+
+      with_webmock_net_connect { yield }
+    end
+
+    def with_webmock_net_connect
+      return yield unless defined?(WebMock)
+
+      webmock_enabled = true
+      WebMock.allow_net_connect!
+      yield
+    ensure
+      WebMock.disable_net_connect! if webmock_enabled
+    end
+
+    def normalize_iana_description(description)
+      description.to_s.gsub(/\s+/, ' ').strip
+    end
+
     it 'has problem descriptions for each mapped ACME error class' do
       Acme::Client::Error::ACME_ERRORS.each_key do |type|
         problem = described_class.new('type' => type)
         expect(problem.description).not_to be_nil
       end
+    end
+
+    it 'matches the live IANA ACME error type registry' do
+      registered_descriptions = described_class::REGISTERED_ERROR_TYPE_DESCRIPTIONS
+      registered_types = registered_descriptions.keys
+      iana_types = iana_registry.keys
+      missing_types = iana_types - registered_types
+      extra_types = registered_types - iana_types
+      mismatched_descriptions = iana_registry.each_with_object({}) do |(type, description), mismatches|
+        next unless registered_descriptions.key?(type)
+        next if normalize_iana_description(registered_descriptions[type]) == description
+
+        mismatches[type] = {
+          iana: description,
+          registered: normalize_iana_description(registered_descriptions[type])
+        }
+      end
+      missing_error_classes = iana_types.map { |type| "#{described_class::ERROR_PREFIX}#{type}" } - Acme::Client::Error::ACME_ERRORS.keys
+
+      expect(missing_types).to be_empty, "missing registered ACME problem descriptions: #{missing_types.join(', ')}"
+      expect(extra_types).to be_empty, "extra registered ACME problem descriptions: #{extra_types.join(', ')}"
+      expect(mismatched_descriptions).to be_empty, "mismatched IANA ACME problem descriptions: #{mismatched_descriptions.inspect}"
+      expect(missing_error_classes).to be_empty, "missing ACME error classes: #{missing_error_classes.join(', ')}"
     end
 
     it 'maps registered extension error types to typed errors' do

--- a/spec/typed_challenge_error_spec.rb
+++ b/spec/typed_challenge_error_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe 'Typed errors from challenge error fields' do
       err = challenge.typed_error
       expect(err).to be_a(Acme::Client::Error::Dns)
       expect(err.message).to eq('DNS problem: SERVFAIL looking up A for example.com')
+      expect(err.problem).to be_a(Acme::Client::Problem)
+      expect(err.problem.code).to eq('dns')
     end
 
     it 'returns a typed Unauthorized error' do
@@ -42,6 +44,8 @@ RSpec.describe 'Typed errors from challenge error fields' do
       })
       err = challenge.typed_error
       expect(err).to be_a(Acme::Client::Error::Unauthorized)
+      expect(err.problem).to be_a(Acme::Client::Problem)
+      expect(err.problem.code).to eq('unauthorized')
     end
 
     it 'returns a typed Connection error' do
@@ -88,6 +92,8 @@ RSpec.describe 'Typed errors from challenge error fields' do
       err = challenge.typed_error
       expect(err).to be_a(Acme::Client::Error)
       expect(err.message).to eq('Something new happened')
+      expect(err.problem.code).to eq('unknownFutureThing')
+      expect(err.problem).not_to be_standard
     end
 
     it 'uses "Unknown error" when detail is missing' do
@@ -97,6 +103,7 @@ RSpec.describe 'Typed errors from challenge error fields' do
       err = challenge.typed_error
       expect(err).to be_a(Acme::Client::Error::Dns)
       expect(err.message).to eq('Unknown error')
+      expect(err.problem.code).to eq('dns')
     end
 
     it 'does not alter the raw error hash' do


### PR DESCRIPTION
## Summary

This adds `Acme::Client::Problem`, a structured wrapper for [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807) problem documents as used by ACME and extended by [RFC 8555](https://datatracker.ietf.org/doc/html/rfc8555).

## What changed

- Exposes problem document fields through `#type`, `#code`, `#title`, `#detail`, `#status`, `#instance`, `#identifier`, `#subproblems`, and `#raw`.
- Keeps `#acme_error_body` and existing typed exception behavior intact for backwards compatibility.
- Adds `#problem` to `Acme::Client::Error` so callers can inspect structured problem details without parsing raw hashes or human-readable messages.
- Adds typed error mappings for currently registered [ACME error types](https://www.iana.org/assignments/acme/acme.xhtml#acme-error-types) that were missing from `ACME_ERRORS`.
- Attaches structured problems to challenge `#typed_error` results.

## Notes

This intentionally does not interpret provider-specific `detail` strings or add policy decisions on top of ACME error types. It only exposes the structured problem document and registered ACME type metadata so callers can make their own retry, fallback, logging, or alerting decisions.
